### PR TITLE
Issue 4 update layout with new data

### DIFF
--- a/LayoutTest.xcodeproj/project.pbxproj
+++ b/LayoutTest.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		61CACFB41C1A4FF500369461 /* LYTDeviceConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61CACFB21C1A4FF500369461 /* LYTDeviceConstants.m */; };
 		61CACFB61C1A560000369461 /* LayoutTestCaseViewSizesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61CACFB51C1A560000369461 /* LayoutTestCaseViewSizesTests.m */; };
 		61CACFB81C1A592000369461 /* LayoutTestCaseViewSizesConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61CACFB71C1A592000369461 /* LayoutTestCaseViewSizesConfigTests.m */; };
+		C56317F11C6373FE00A8E8BA /* LayoutTestCaseMultipleDataOverlapTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C56317F01C6373FE00A8E8BA /* LayoutTestCaseMultipleDataOverlapTests.m */; };
+		C56317F41C63746C00A8E8BA /* UIViewWithLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = C56317F31C63746C00A8E8BA /* UIViewWithLabel.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -164,6 +166,9 @@
 		61CACFB21C1A4FF500369461 /* LYTDeviceConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LYTDeviceConstants.m; sourceTree = "<group>"; };
 		61CACFB51C1A560000369461 /* LayoutTestCaseViewSizesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LayoutTestCaseViewSizesTests.m; sourceTree = "<group>"; };
 		61CACFB71C1A592000369461 /* LayoutTestCaseViewSizesConfigTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LayoutTestCaseViewSizesConfigTests.m; sourceTree = "<group>"; };
+		C56317F01C6373FE00A8E8BA /* LayoutTestCaseMultipleDataOverlapTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LayoutTestCaseMultipleDataOverlapTests.m; sourceTree = "<group>"; };
+		C56317F21C63746C00A8E8BA /* UIViewWithLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIViewWithLabel.h; sourceTree = "<group>"; };
+		C56317F31C63746C00A8E8BA /* UIViewWithLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIViewWithLabel.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -228,6 +233,8 @@
 			children = (
 				614FE6A51C03F05E00BB9EE6 /* UnitTestViews.h */,
 				614FE6A61C03F05E00BB9EE6 /* UnitTestViews.m */,
+				C56317F21C63746C00A8E8BA /* UIViewWithLabel.h */,
+				C56317F31C63746C00A8E8BA /* UIViewWithLabel.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -244,6 +251,7 @@
 				614FE6AF1C03F05E00BB9EE6 /* LayoutTestCaseWithinSuperviewTests.m */,
 				61CACFB51C1A560000369461 /* LayoutTestCaseViewSizesTests.m */,
 				61CACFB71C1A592000369461 /* LayoutTestCaseViewSizesConfigTests.m */,
+				C56317F01C6373FE00A8E8BA /* LayoutTestCaseMultipleDataOverlapTests.m */,
 			);
 			path = LayoutTestCaseTests;
 			sourceTree = "<group>";
@@ -616,8 +624,10 @@
 				614FE6BB1C03F05E00BB9EE6 /* LayoutTestCaseMissingLabelTests.m in Sources */,
 				614FE6D01C050F4000BB9EE6 /* FrameComparisonTests.m in Sources */,
 				614FE6BE1C03F05E00BB9EE6 /* LayoutTestCaseWithinSuperviewTests.m in Sources */,
+				C56317F41C63746C00A8E8BA /* UIViewWithLabel.m in Sources */,
 				61CACFB61C1A560000369461 /* LayoutTestCaseViewSizesTests.m in Sources */,
 				614FE6BD1C03F05E00BB9EE6 /* LayoutTestCaseOverlapTests.m in Sources */,
+				C56317F11C6373FE00A8E8BA /* LayoutTestCaseMultipleDataOverlapTests.m in Sources */,
 				614FE6C31C03F11300BB9EE6 /* SwiftLayoutTestCaseTests.swift in Sources */,
 				614FE6B41C03F05E00BB9EE6 /* ConfigTests.m in Sources */,
 				614FE6B61C03F05E00BB9EE6 /* UnitTestViews.m in Sources */,

--- a/LayoutTestBase/Core/Testers/LYTLayoutPropertyTester.m
+++ b/LayoutTestBase/Core/Testers/LYTLayoutPropertyTester.m
@@ -145,6 +145,7 @@
     if ([(id)viewProvider respondsToSelector:@selector(adjustViewSize:data:size:context:)]) {
         [viewProvider adjustViewSize:view data:data size:size context:context];
     }
+    [view setNeedsLayout];
     [view layoutIfNeeded];
     validation(view, data, context);
     return view;

--- a/LayoutTestTests/Helpers/UIViewWithLabel.h
+++ b/LayoutTestTests/Helpers/UIViewWithLabel.h
@@ -1,0 +1,16 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+#import <UIKit/UIKit.h>
+
+@interface UIViewWithLabel : UIView
+
+@property (nonatomic) UILabel *label;
+
+@end

--- a/LayoutTestTests/Helpers/UIViewWithLabel.m
+++ b/LayoutTestTests/Helpers/UIViewWithLabel.m
@@ -1,0 +1,14 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+#import "UIViewWithLabel.h"
+
+@implementation UIViewWithLabel
+
+@end

--- a/LayoutTestTests/Helpers/UnitTestViews.h
+++ b/LayoutTestTests/Helpers/UnitTestViews.h
@@ -10,6 +10,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+@class UIViewWithLabel;
 
 @interface UnitTestViews : NSObject
 
@@ -32,5 +33,7 @@
 + (UIView *)viewWithNestedAccessibility;
 
 + (UIView *)viewWithAccessibilityIDButNoLabel;
+
++ (UIViewWithLabel *)viewWithLongStringOverlappingLabel;
 
 @end

--- a/LayoutTestTests/Helpers/UnitTestViews.m
+++ b/LayoutTestTests/Helpers/UnitTestViews.m
@@ -8,6 +8,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 #import "UnitTestViews.h"
+#import "UIViewWithLabel.h"
 
 @interface AmbiguousLayoutView : UIView
 
@@ -148,6 +149,31 @@
 
     view1.accessibilityIdentifier = @"ID but no label?";
 
+    return superview;
+}
+
++ (UIViewWithLabel *)viewWithLongStringOverlappingLabel {
+    UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 22, 10)];
+    UIView *view2 = [[UIView alloc] initWithFrame:CGRectMake(23, 0, 10, 10)];
+    NSDictionary *viewsDictionary = NSDictionaryOfVariableBindings(label, view2);
+    UIViewWithLabel *superview = [[UIViewWithLabel alloc] initWithFrame:CGRectMake(0, 0, 272, 22)];
+    
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.text = @"X";
+    
+    view2.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    [superview addSubview:label];
+    [superview addSubview:view2];
+    superview.label = label;
+    superview.translatesAutoresizingMaskIntoConstraints = NO;
+    [superview addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-0-[label]" options:NSLayoutFormatAlignAllTop metrics:nil views:viewsDictionary]];
+    [superview addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[view2(10)]-0-|" options:NSLayoutFormatAlignAllTop metrics:nil views:viewsDictionary]];
+    [superview addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[label]-0-|" options:NSLayoutFormatAlignAllTop metrics:nil views:viewsDictionary]];
+    [superview addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[view2]-0-|" options:NSLayoutFormatAlignAllTop metrics:nil views:viewsDictionary]];
+    [superview addConstraint:[NSLayoutConstraint constraintWithItem:superview attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:272]];
+    [superview addConstraint:[NSLayoutConstraint constraintWithItem:superview attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:22]];
+    
     return superview;
 }
 

--- a/LayoutTestTests/Helpers/UnitTestViews.m
+++ b/LayoutTestTests/Helpers/UnitTestViews.m
@@ -163,6 +163,11 @@
     
     view2.translatesAutoresizingMaskIntoConstraints = NO;
     
+    // Constraints for
+    // - the label pinned to the left but using it's intrinsic content size to determine it's width
+    // - the second view pinned to the right with a fixed width
+    // - the superview with a fixed width and height
+    // With these constraints the label on the left will overlap the second view with a long string
     [superview addSubview:label];
     [superview addSubview:view2];
     superview.label = label;

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseMultipleDataOverlapTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseMultipleDataOverlapTests.m
@@ -42,7 +42,7 @@
 + (NSDictionary *)dataSpecForTest {
     return @{
              @"view": [UnitTestViews viewWithLongStringOverlappingLabel],
-             @"text": [[LYTDataValues alloc] initWithValues:@[@"X", @"A long string that will cause overlap"]]
+             @"text": [[LYTStringValues alloc] initWithValues:@[@"X", @"A long string that will cause overlap"]]
              };
 }
 

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseMultipleDataOverlapTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseMultipleDataOverlapTests.m
@@ -1,0 +1,55 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+#import "LayoutTest.h"
+#import "LayoutTestBase.h"
+#import "UnitTestViews.h"
+#import "UIViewWithLabel.h"
+
+@interface LayoutTestCaseMultipleDataOverlapTests : LYTLayoutTestCase <LYTViewProvider>
+
+@property (nonatomic) NSInteger testFailures;
+
+@end
+
+@implementation LayoutTestCaseMultipleDataOverlapTests
+
+- (void)testPassWithoutOverlappingTextAndFailWithOverlappingText {
+    __block NSInteger timesCalled = 0;
+    
+    [self runLayoutTestsWithViewProvider:[self class] validation:^(UIView * view, NSDictionary * data, id context) {
+        timesCalled++;
+    }];
+    
+    XCTAssertEqual(timesCalled, 2);
+    XCTAssertEqual(self.testFailures, 1);
+}
+
+#pragma mark - Override
+
+- (void)failTest:(NSString *)errorMessage view:(UIView *)view {
+    self.testFailures++;
+}
+
+#pragma mark - LYTViewProvider
+
++ (NSDictionary *)dataSpecForTest {
+    return @{
+             @"view": [UnitTestViews viewWithLongStringOverlappingLabel],
+             @"text": [[LYTDataValues alloc] initWithValues:@[@"X", @"A long string that will cause overlap"]]
+             };
+}
+
++ (UIView *)viewForData:(NSDictionary *)data reuseView:(UIView *)view size:(LYTViewSize *)size context:(id *)context {
+    UIViewWithLabel *reuseView = (UIViewWithLabel *)(view ? view : data[@"view"]);
+    reuseView.label.text = data[@"text"];
+    return reuseView;
+}
+
+@end


### PR DESCRIPTION
Added a test-case demonstrating that changing the text on a label from new test-data does not cause the label to be resized for the layout tests.

Added a fix to force re-laying out for each piece of data.