### PR TITLE
Issue 1 - Adding Snapshots support for failing tests

### DIFF
--- a/LayoutTest.xcodeproj/project.pbxproj
+++ b/LayoutTest.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5667F66B1C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 5667F6691C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.h */; };
+		5667F66C1C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 5667F66A1C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.m */; };
+		5667F66F1C6600FA0042C3BB /* LYTLayoutFailingTestSnapshotRecorderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5667F66D1C6600FA0042C3BB /* LYTLayoutFailingTestSnapshotRecorderTests.m */; };
+		5667F6701C6600FA0042C3BB /* SwiftLYTLayoutFailingTestSnapshotRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5667F66E1C6600FA0042C3BB /* SwiftLYTLayoutFailingTestSnapshotRecorderTests.swift */; };
+		5667F6721C6602730042C3BB /* LayoutTest-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 5667F6711C6602730042C3BB /* LayoutTest-Bridging-Header.h */; };
 		614FE6431C03EE3C00BB9EE6 /* LayoutTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 614FE6391C03EE3C00BB9EE6 /* LayoutTest.framework */; };
 		614FE6A01C03EF6A00BB9EE6 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6152970D187CAEEC00BAF959 /* XCTest.framework */; };
 		614FE6B31C03F05E00BB9EE6 /* AutolayoutFailureInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 614FE6A11C03F05E00BB9EE6 /* AutolayoutFailureInterceptorTests.m */; };
@@ -73,6 +78,7 @@
 		61CACFB81C1A592000369461 /* LayoutTestCaseViewSizesConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61CACFB71C1A592000369461 /* LayoutTestCaseViewSizesConfigTests.m */; };
 		C56317F11C6373FE00A8E8BA /* LayoutTestCaseMultipleDataOverlapTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C56317F01C6373FE00A8E8BA /* LayoutTestCaseMultipleDataOverlapTests.m */; };
 		C56317F41C63746C00A8E8BA /* UIViewWithLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = C56317F31C63746C00A8E8BA /* UIViewWithLabel.m */; };
+		C59A16451C6A2C20002AC07C /* LayoutReportSnapshotLocationsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C59A16441C6A2C20002AC07C /* LayoutReportSnapshotLocationsTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +99,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5667F6691C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LYTLayoutFailingTestSnapshotRecorder.h; sourceTree = "<group>"; };
+		5667F66A1C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LYTLayoutFailingTestSnapshotRecorder.m; sourceTree = "<group>"; };
+		5667F66D1C6600FA0042C3BB /* LYTLayoutFailingTestSnapshotRecorderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LYTLayoutFailingTestSnapshotRecorderTests.m; sourceTree = "<group>"; };
+		5667F66E1C6600FA0042C3BB /* SwiftLYTLayoutFailingTestSnapshotRecorderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftLYTLayoutFailingTestSnapshotRecorderTests.swift; sourceTree = "<group>"; };
+		5667F6711C6602730042C3BB /* LayoutTest-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "LayoutTest-Bridging-Header.h"; sourceTree = "<group>"; };
 		613272E418A2BB7400036061 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		614FE6391C03EE3C00BB9EE6 /* LayoutTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LayoutTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		614FE63D1C03EE3C00BB9EE6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -169,6 +180,7 @@
 		C56317F01C6373FE00A8E8BA /* LayoutTestCaseMultipleDataOverlapTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LayoutTestCaseMultipleDataOverlapTests.m; sourceTree = "<group>"; };
 		C56317F21C63746C00A8E8BA /* UIViewWithLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIViewWithLabel.h; sourceTree = "<group>"; };
 		C56317F31C63746C00A8E8BA /* UIViewWithLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIViewWithLabel.m; sourceTree = "<group>"; };
+		C59A16441C6A2C20002AC07C /* LayoutReportSnapshotLocationsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LayoutReportSnapshotLocationsTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -202,6 +214,7 @@
 		614FE63A1C03EE3C00BB9EE6 /* LayoutTest */ = {
 			isa = PBXGroup;
 			children = (
+				5667F6711C6602730042C3BB /* LayoutTest-Bridging-Header.h */,
 				61A306671C125A8000CB3FEC /* LayoutTest.h */,
 				61ADE1C31C0CA81600585946 /* Swift */,
 				61ADE2331C0CAFE900585946 /* TestCase */,
@@ -242,6 +255,8 @@
 		614FE6A81C03F05E00BB9EE6 /* LayoutTestCaseTests */ = {
 			isa = PBXGroup;
 			children = (
+				5667F66D1C6600FA0042C3BB /* LYTLayoutFailingTestSnapshotRecorderTests.m */,
+				5667F66E1C6600FA0042C3BB /* SwiftLYTLayoutFailingTestSnapshotRecorderTests.swift */,
 				614FE6A91C03F05E00BB9EE6 /* LayoutTestCaseAccessibilityControlTests.m */,
 				614FE6AA1C03F05E00BB9EE6 /* LayoutTestCaseAmbiguousTests.m */,
 				614FE6AB1C03F05E00BB9EE6 /* LayoutTestCaseAutolayoutFailureTests.m */,
@@ -252,6 +267,7 @@
 				61CACFB51C1A560000369461 /* LayoutTestCaseViewSizesTests.m */,
 				61CACFB71C1A592000369461 /* LayoutTestCaseViewSizesConfigTests.m */,
 				C56317F01C6373FE00A8E8BA /* LayoutTestCaseMultipleDataOverlapTests.m */,
+				C59A16441C6A2C20002AC07C /* LayoutReportSnapshotLocationsTests.m */,
 			);
 			path = LayoutTestCaseTests;
 			sourceTree = "<group>";
@@ -415,6 +431,8 @@
 		61ADE2331C0CAFE900585946 /* TestCase */ = {
 			isa = PBXGroup;
 			children = (
+				5667F6691C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.h */,
+				5667F66A1C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.m */,
 				61ADE2341C0CAFE900585946 /* LYTLayoutTestCase.h */,
 				61ADE2351C0CAFE900585946 /* LYTLayoutTestCase.m */,
 			);
@@ -441,6 +459,8 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5667F66B1C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.h in Headers */,
+				5667F6721C6602730042C3BB /* LayoutTest-Bridging-Header.h in Headers */,
 				61A306681C125A8000CB3FEC /* LayoutTest.h in Headers */,
 				61ADE2491C0CAFE900585946 /* LYTLayoutTestCase.h in Headers */,
 			);
@@ -603,6 +623,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61ADE24A1C0CAFE900585946 /* LYTLayoutTestCase.m in Sources */,
+				5667F66C1C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.m in Sources */,
 				61ADE1E81C0CA81600585946 /* LayoutTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -620,6 +641,8 @@
 				614FE6B91C03F05E00BB9EE6 /* LayoutTestCaseAmbiguousTests.m in Sources */,
 				614FE6B51C03F05E00BB9EE6 /* DataValuesTests.m in Sources */,
 				614FE6B31C03F05E00BB9EE6 /* AutolayoutFailureInterceptorTests.m in Sources */,
+				C59A16451C6A2C20002AC07C /* LayoutReportSnapshotLocationsTests.m in Sources */,
+				5667F66F1C6600FA0042C3BB /* LYTLayoutFailingTestSnapshotRecorderTests.m in Sources */,
 				614FE6B81C03F05E00BB9EE6 /* LayoutTestCaseAccessibilityControlTests.m in Sources */,
 				614FE6BB1C03F05E00BB9EE6 /* LayoutTestCaseMissingLabelTests.m in Sources */,
 				614FE6D01C050F4000BB9EE6 /* FrameComparisonTests.m in Sources */,
@@ -628,6 +651,7 @@
 				61CACFB61C1A560000369461 /* LayoutTestCaseViewSizesTests.m in Sources */,
 				614FE6BD1C03F05E00BB9EE6 /* LayoutTestCaseOverlapTests.m in Sources */,
 				C56317F11C6373FE00A8E8BA /* LayoutTestCaseMultipleDataOverlapTests.m in Sources */,
+				5667F6701C6600FA0042C3BB /* SwiftLYTLayoutFailingTestSnapshotRecorderTests.swift in Sources */,
 				614FE6C31C03F11300BB9EE6 /* SwiftLayoutTestCaseTests.swift in Sources */,
 				614FE6B41C03F05E00BB9EE6 /* ConfigTests.m in Sources */,
 				614FE6B61C03F05E00BB9EE6 /* UnitTestViews.m in Sources */,
@@ -818,6 +842,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "LayoutTest/LayoutTest-Bridging-Header.h";
 			};
 			name = Debug;
 		};
@@ -849,6 +874,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "LayoutTest/LayoutTest-Bridging-Header.h";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/LayoutTest/LayoutTest-Bridging-Header.h
+++ b/LayoutTest/LayoutTest-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "LYTLayoutFailingTestSnapshotRecorder.h"

--- a/LayoutTest/TestCase/LYTLayoutFailingTestSnapshotRecorder.h
+++ b/LayoutTest/TestCase/LYTLayoutFailingTestSnapshotRecorder.h
@@ -1,0 +1,51 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+@interface LYTLayoutFailingTestSnapshotRecorder : NSObject<XCTestObservation>
+
+/**
+ Singleton accessor.
+ */
++ (instancetype)sharedInstance;
+
+/**
+ Creates the new folder structure and starts index.html file for the given class. If a folder already exists for the class it will be deleted first to clear any images previously saved for failing tests in that class.
+ 
+ Folder structure for images follows the pattern: {DERIVED_DATA}/LayoutTestImages/{CLASS_NAME}/index.html
+ Index.html file includes tables with failure description, image and the data that the image failed with.
+ 
+  \param invocationClass The class to start a new log for, class name is used in the directory structure to save the snapshots.
+ */
+- (void)startNewLogForClass:(Class)invocationClass;
+
+/**
+ Finishes the index.html log for the current invocation class by adding closing html tags.
+ Can be called safely without calling startNewLogForClass: as no index.html file for the class with exists so nothing will happen.
+ 
+ Then file path to the index.html file for the current class is saved after all of the tests in the test class finish running. Once all test classes in  have finished all saved failing test index.html file paths are logged to the console.
+ */
+- (void)finishLog;
+
+/**
+ Renders the view passed as a png and saves it. The failure description, image and data are added to the index.html file for the current test class.
+ The invocation is used to create a folder for the invocations method name and the failing views for that invocation are saved within. Folder structure for invocation follows the pattern: {DERIVED_DATA}/LayoutTestImages/{CLASS_NAME}/{METHOD_NAME}/
+ Images sare saved with the file name format: Width-{VIEW_WIDTH}_Height-{VIEW_HEIGHT}_Data-{DATA_DESCRIPTION_HASH}.png
+ 
+ \param view The view to save a image of.
+ \param data The data that was used to poulate the view
+ \param invocation The invocation for the current test. When used from a XCTestCase subclass the invocation will include the name of the test method currently being run.
+ \param failureDescription The description of why the view that is being saved failed its layout tests.
+ */
+- (void)saveImageOfView:(UIView *)view withData:(NSDictionary *)data fromInvocation:(NSInvocation *)invocation failureDescription:(NSString *)failureDescription;
+
+@end

--- a/LayoutTest/TestCase/LYTLayoutFailingTestSnapshotRecorder.m
+++ b/LayoutTest/TestCase/LYTLayoutFailingTestSnapshotRecorder.m
@@ -1,0 +1,228 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+#import "LYTLayoutFailingTestSnapshotRecorder.h"
+#import "LYTConfig.h"
+#import "LYTLayoutTestCase.h"
+
+void SimpleLog(NSString *format, ...) {
+    // Log to the console without timestamp that NSLog gives us
+    va_list args;
+    va_start(args, format);
+    NSString *formattedString = [[NSString alloc] initWithFormat:format
+                                                       arguments:args];
+    va_end(args);
+    [[NSFileHandle fileHandleWithStandardOutput] writeData:[formattedString dataUsingEncoding:NSNEXTSTEPStringEncoding]];
+}
+
+@interface LYTLayoutFailingTestSnapshotRecorder ()
+
+@property (nonatomic) Class invocationClass;
+@property (nonatomic) NSMutableSet *failingTestsSnapshotFolders;
+
+@end
+
+@implementation LYTLayoutFailingTestSnapshotRecorder
+
++ (instancetype)sharedInstance {
+    static LYTLayoutFailingTestSnapshotRecorder *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[LYTLayoutFailingTestSnapshotRecorder alloc] init];
+    });
+    return sharedInstance;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.failingTestsSnapshotFolders = [NSMutableSet set];
+        XCTestObservationCenter *observationCenter = [XCTestObservationCenter sharedTestObservationCenter];
+        [observationCenter addTestObserver:self];
+    }
+    return self;
+}
+
+- (void)testBundleDidFinish:(NSBundle *)testBundle {
+    if (self.failingTestsSnapshotFolders.count > 0) {
+        SimpleLog(@"\nSnapshots of failing tests can be found in:\n");
+        for (NSString *path in self.failingTestsSnapshotFolders) {
+            SimpleLog(@"%@\n", path);
+        }
+        [self.failingTestsSnapshotFolders removeAllObjects];
+    }
+}
+
+- (void)testCase:(XCTestCase *)testCase didFailWithDescription:(NSString *)description inFile:(nullable NSString *)filePath atLine:(NSUInteger)lineNumber {
+    if ([testCase isKindOfClass:[LYTLayoutTestCase class]]) {
+        NSString *pathForSnapshots = [self commonRootPathForInvocationClass:[testCase class]];
+        pathForSnapshots = [pathForSnapshots stringByAppendingString:@"/index.html"];
+        [self.failingTestsSnapshotFolders addObject:pathForSnapshots];
+    }
+}
+
+- (void)startNewLogForClass:(Class)invocationClass {
+    self.invocationClass = invocationClass;
+    [self deleteCurrentFailingSnapshotsForInvocationClass:invocationClass];
+    [self createIndexHTMLFile];
+}
+
+- (void)saveImageOfView:(UIView *)view withData:(NSDictionary *)data fromInvocation:(NSInvocation *)invocation failureDescription:(NSString *)failureDescription {
+    NSString *imagePath = [self pathForImageWithWidth:view.frame.size.width height:view.frame.size.height data:data invocation:invocation];
+    if ([self shouldSaveImageOfViewAtPath:imagePath withInvocation:invocation]) {
+        [self createDirectoryForInvocationIfNeeded:invocation];
+        UIImage *viewImage = [self renderLayer:view.layer];
+        [UIImagePNGRepresentation(viewImage) writeToFile:imagePath atomically:YES];
+        [self appendViewWithWidth:view.frame.size.width
+                           height:view.frame.size.height
+                         viewData:data
+      toLogWithFailureDescription:failureDescription
+                   withInvocation:invocation];
+    }
+}
+
+- (BOOL)shouldSaveImageOfViewAtPath:(NSString *)imagePath withInvocation:(NSInvocation *)invocation {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:imagePath]) {
+        return NO;
+    } else if ([LYTConfig sharedInstance].snapshotsToSavePerMethod != LYTSaveUnlimitedSnapshotsPerMethod &&
+               [self numberOfImagesSavedForInvocation:invocation] >= [LYTConfig sharedInstance].snapshotsToSavePerMethod) {
+        return NO;
+    }
+    
+    return YES;
+}
+
+- (NSUInteger)numberOfImagesSavedForInvocation:(NSInvocation *)invocation {
+    return [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[self directoryPathForCurrentInvocation:invocation] error:nil].count;
+}
+
+- (void)createIndexHTMLFile {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *classNameDirectory = [self commonRootPathForInvocationClass:self.invocationClass];
+    NSString *filePath = [self indexHTMLFilePath];
+    
+    NSString *header = @"<HTML><HEAD></HEAD><BODY><TABLE style='width:100%'><TR><TH>Description</TH><TH>Image</TH><TH>Input Data</TH></TR>";
+    
+    [fileManager createDirectoryAtPath:classNameDirectory withIntermediateDirectories:YES attributes:nil error:nil];
+    [fileManager createFileAtPath:filePath contents:nil attributes:nil];
+    
+    // Write to the file
+    [header writeToFile:filePath atomically:YES
+               encoding:NSUTF8StringEncoding error:nil];
+}
+
+- (void)finishLog {
+    NSString *filePath = [self indexHTMLFilePath];
+    NSString *footer = @"</TABLE></BODY></HTML>";
+    NSFileHandle *fileHandler = [NSFileHandle fileHandleForUpdatingAtPath:filePath];
+    
+    [fileHandler seekToEndOfFile];
+    [fileHandler writeData:[footer dataUsingEncoding:NSUTF8StringEncoding]];
+    [fileHandler closeFile];
+}
+
+- (void)appendViewWithWidth:(CGFloat)width
+                     height:(CGFloat)height
+                   viewData:(NSDictionary *)data
+            toLogWithFailureDescription:(NSString *)description
+             withInvocation:(NSInvocation *)invocation {
+    if (!description) {
+        description = @"";
+    }
+    
+    NSString *filePath = [self indexHTMLFilePath];
+    NSString *imagePath = [NSString stringWithFormat:@"%@/%@", [self methodNameForInvocation:invocation], [self nameForImageWithWidth:width height:height data:data]];
+    NSString *errorHTML = [NSString stringWithFormat:@"<TR><TD>%@</TD><TD><IMG src='%@' alt='No Image'></TD><TD>%@</TD></TR>", description, imagePath, data.description];
+    errorHTML = [errorHTML stringByReplacingOccurrencesOfString:@"\n" withString:@""];
+    NSFileHandle *fileHandler = [NSFileHandle fileHandleForUpdatingAtPath:filePath];
+    
+    [fileHandler seekToEndOfFile];
+    [fileHandler writeData:[errorHTML dataUsingEncoding:NSUTF8StringEncoding]];
+    [fileHandler closeFile];
+}
+
+- (NSString *)indexHTMLFilePath {
+    NSString *documentsDirectory = [self commonRootPathForInvocationClass:self.invocationClass];
+    return [documentsDirectory stringByAppendingPathComponent:@"index.html"];
+}
+
+- (void)deleteCurrentFailingSnapshotsForInvocationClass:(Class)invocationClass {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    [fileManager removeItemAtPath:[self commonRootPathForInvocationClass:invocationClass] error:nil];
+}
+
+- (void)createDirectoryForInvocationIfNeeded:(NSInvocation *)invocation {
+    NSString *directoryPath = [self directoryPathForCurrentInvocation:invocation];
+    if (![[NSFileManager defaultManager] fileExistsAtPath:directoryPath isDirectory:nil]) {
+        [[NSFileManager defaultManager] createDirectoryAtPath:directoryPath withIntermediateDirectories:YES attributes:nil error:nil];
+    }
+}
+
+/**
+ Returns the path to the directory to save snapshots of the current failing test. Path includes class and method name
+ e.g. {FULL_PATH}/SamepleTableViewCellLayoutTests/testSampleTableViewCell
+ */
+- (NSString *)directoryPathForCurrentInvocation:(NSInvocation *)invocation {
+    NSString *documentsDirectory = [self commonRootPathForInvocationClass:self.invocationClass];
+    
+    NSString *directoryPath = [documentsDirectory stringByAppendingString:[NSString stringWithFormat:@"/%@", [self methodNameForInvocation:invocation]]];
+    return directoryPath;
+}
+
+- (NSString *)methodNameForInvocation:(NSInvocation *)invocation {
+    return NSStringFromSelector((SEL)[invocation selector]);
+}
+
+- (NSString *)commonRootPathForInvocationClass:(Class)classForRoot {
+    NSString *currentDirectory = [[NSBundle bundleForClass:classForRoot] bundlePath];
+    NSString *className = NSStringFromClass(classForRoot);
+    //Check incase the class name includes a ".", if so we the actual class name will be everything after the "."
+    if ([className containsString:@"."]) {
+        className = [className componentsSeparatedByString:@"."].lastObject;
+    }
+    
+    return [currentDirectory stringByAppendingPathComponent:[NSString stringWithFormat:@"LayoutTestImages/%@", className]];
+}
+
+/**
+ Returns the full path to the image with the given file name and the iamge size and width appended to it.
+ e.g. {DIRECTORY_PATH}/SamepleTableViewCellLayoutTests/testSampleTableViewCell/{FILE_NAME}_{IMAGE_WIDTH}_{IMAGE_HEIGHT}.png
+ */
+- (NSString *)pathForImageWithWidth:(CGFloat)width height:(CGFloat)height data:(NSDictionary *)data invocation:(NSInvocation *)invocation {
+    NSString *directoryPath = [self directoryPathForCurrentInvocation:invocation];
+    NSString *imageName = [self nameForImageWithWidth:width height:height data:data];
+    return [directoryPath stringByAppendingPathComponent:imageName];
+}
+
+- (NSString *)nameForImageWithWidth:(CGFloat)width height:(CGFloat)height data:(NSDictionary *)data {
+    NSString *imageName = [NSString stringWithFormat:@"Width-%.2f_Height-%.2f_Data-%lu", width, height, (unsigned long)data.description.hash];
+    return [imageName stringByAppendingString:@".png"];
+}
+
+- (UIImage *)renderLayer:(CALayer *)layer {
+    UIImage *snapshot = nil;
+    CGRect bounds = layer.bounds;
+    if (CGRectGetWidth(bounds) > 0 && CGRectGetHeight(bounds) > 0) {
+        UIGraphicsBeginImageContextWithOptions(bounds.size, NO, 0);
+        CGContextRef context = UIGraphicsGetCurrentContext();
+
+        CGContextSaveGState(context);
+        {
+            [layer renderInContext:context];
+        }
+        CGContextRestoreGState(context);
+        
+        snapshot = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+    }
+    
+    return snapshot;
+}
+
+@end

--- a/LayoutTest/TestCase/LYTLayoutTestCase.h
+++ b/LayoutTest/TestCase/LYTLayoutTestCase.h
@@ -166,6 +166,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL accessibilityTestsEnabled;
 
 /**
+ If on, a snapshot of the view for the current failing test will be saved to the derived data folder. The data for the failing test is also logged in the index.html file for each LYTLayoutTestCase sub class. The path to the folder is logged after the test suite has finished.
+ 
+ You can also globally set this as a default in LYTConfig.
+ 
+ Default: true
+ */
+@property (nonatomic) BOOL failingTestSnapshotsEnabled;
+
+/**
  When we traverse the view hierarchy, we expect some elements to always have accessibility labels. For instance, UIControls should have accessibility
  labels or they won't be useable by accessibility users. Any element which subclasses one of these classes should have an accessibility label.
  

--- a/LayoutTestBase/Config/LYTConfig.h
+++ b/LayoutTestBase/Config/LYTConfig.h
@@ -71,6 +71,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL accessibilityTestsEnabled;
 
 /**
+ If on, a snapshot of the view for the current failing test will be saved to the derived data folder. The data for the failing test is also logged in the index.html file for each LYTLayoutTestCase sub class. The path to the folder is logged after the test suite has finished.
+ 
+ This property can also be turned on/off on each LayoutTestCase.
+ 
+ Default: true
+ */
+@property (nonatomic) BOOL failingTestSnapshotsEnabled;
+
+/**
  When we traverse the view hierarchy, we expect some elements to always have accessibility labels. For instance, UIControls should have accessibility
  labels or they won't be useable by accessibility users. Any element which subclasses one of these classes should have an accessibility label.
 
@@ -106,6 +115,22 @@ NS_ASSUME_NONNULL_BEGIN
  Default: 1e-5
  */
 @property (nonatomic) CGFloat cgFloatEpsilon;
+
+
+/**
+ Default snapshots to save per method.
+ */
+
+extern NSUInteger const LYTSaveUnlimitedSnapshotsPerMethod;
+
+/**
+ Limits the number of snapshots that will be saved for each method in a LYTLayoutTestCase. If a test has multiple XCTAsserts which can fail for each size/data iteration there is the possiblity that hundreds of snapshots will be produced. Setting this to a value of 0 or greater will limit the number of images saved.
+ 
+ This property can only be set in the config.
+ 
+ Default: SaveUnlimitedSnapshotsPerMethod(-1) (Representing unlimited)
+ */
+@property (nonatomic) NSUInteger snapshotsToSavePerMethod;
 
 /**
  Singleton accessor.

--- a/LayoutTestBase/Config/LYTConfig.m
+++ b/LayoutTestBase/Config/LYTConfig.m
@@ -12,6 +12,8 @@
 
 @implementation LYTConfig
 
+NSUInteger const LYTSaveUnlimitedSnapshotsPerMethod = -1;
+
 + (instancetype)sharedInstance {
     static LYTConfig *sharedInstance = nil;
     static dispatch_once_t onceToken;
@@ -34,6 +36,7 @@
     self.ambiguousAutolayoutTestsEnabled = YES;
     self.interceptsAutolayoutErrors = YES;
     self.accessibilityTestsEnabled = YES;
+    self.failingTestSnapshotsEnabled = YES;
     /*
      UISwitch - This is a known class which has internal overlapping subviews.
      UITextView - If you use attributed text, UIKit may add UIImage views which can overlap with the internal text containers.
@@ -44,6 +47,7 @@
      */
     self.viewClassesRequiringAccessibilityLabels = [NSSet setWithObjects:[UIControl class], nil];
     self.cgFloatEpsilon = 1e-5;
+    self.snapshotsToSavePerMethod = LYTSaveUnlimitedSnapshotsPerMethod;
 }
 
 @end

--- a/LayoutTestTests/ConfigTests.m
+++ b/LayoutTestTests/ConfigTests.m
@@ -29,6 +29,7 @@
     [LYTConfig sharedInstance].ambiguousAutolayoutTestsEnabled = NO;
     [LYTConfig sharedInstance].interceptsAutolayoutErrors = NO;
     [LYTConfig sharedInstance].accessibilityTestsEnabled = NO;
+    [LYTConfig sharedInstance].failingTestSnapshotsEnabled = NO;
     [LYTConfig sharedInstance].viewClassesAllowingSubviewErrors = [NSSet set];
     [LYTConfig sharedInstance].viewClassesRequiringAccessibilityLabels = [NSSet set];
 
@@ -39,6 +40,7 @@
     XCTAssertEqual(testCase.ambiguousAutolayoutTestsEnabled, [LYTConfig sharedInstance].ambiguousAutolayoutTestsEnabled);
     XCTAssertEqual(testCase.interceptsAutolayoutErrors, [LYTConfig sharedInstance].interceptsAutolayoutErrors);
     XCTAssertEqual(testCase.accessibilityTestsEnabled, [LYTConfig sharedInstance].accessibilityTestsEnabled);
+    XCTAssertEqual(testCase.failingTestSnapshotsEnabled, [LYTConfig sharedInstance].failingTestSnapshotsEnabled);
     XCTAssertEqual(testCase.viewClassesAllowingSubviewErrors, [LYTConfig sharedInstance].viewClassesAllowingSubviewErrors);
     XCTAssertEqual(testCase.viewClassesRequiringAccessibilityLabels, [LYTConfig sharedInstance].viewClassesRequiringAccessibilityLabels);
 }
@@ -51,8 +53,38 @@
     XCTAssertEqual(testCase.ambiguousAutolayoutTestsEnabled, [LYTConfig sharedInstance].ambiguousAutolayoutTestsEnabled);
     XCTAssertEqual(testCase.interceptsAutolayoutErrors, [LYTConfig sharedInstance].interceptsAutolayoutErrors);
     XCTAssertEqual(testCase.accessibilityTestsEnabled, [LYTConfig sharedInstance].accessibilityTestsEnabled);
+    XCTAssertEqual(testCase.failingTestSnapshotsEnabled, [LYTConfig sharedInstance].failingTestSnapshotsEnabled);
     XCTAssertEqual(testCase.viewClassesAllowingSubviewErrors, [LYTConfig sharedInstance].viewClassesAllowingSubviewErrors);
     XCTAssertEqual(testCase.viewClassesRequiringAccessibilityLabels, [LYTConfig sharedInstance].viewClassesRequiringAccessibilityLabels);
+}
+
+- (void)testResetDefaultsResetsToExpectedValues {
+    [LYTConfig sharedInstance].viewOverlapTestsEnabled = NO;
+    [LYTConfig sharedInstance].viewWithinSuperviewTestsEnabled = NO;
+    [LYTConfig sharedInstance].ambiguousAutolayoutTestsEnabled = NO;
+    [LYTConfig sharedInstance].interceptsAutolayoutErrors = NO;
+    [LYTConfig sharedInstance].accessibilityTestsEnabled = NO;
+    [LYTConfig sharedInstance].failingTestSnapshotsEnabled = NO;
+    [LYTConfig sharedInstance].viewClassesAllowingSubviewErrors = [NSSet setWithObjects:self.class, nil];
+    [LYTConfig sharedInstance].viewClassesRequiringAccessibilityLabels = [NSSet setWithObjects:self.class, nil];
+    [LYTConfig sharedInstance].cgFloatEpsilon = 100;
+    [LYTConfig sharedInstance].snapshotsToSavePerMethod = 100;
+    
+    [[LYTConfig sharedInstance] resetDefaults];
+    
+    XCTAssertEqual(YES, [LYTConfig sharedInstance].viewOverlapTestsEnabled);
+    XCTAssertEqual(YES, [LYTConfig sharedInstance].viewWithinSuperviewTestsEnabled);
+    XCTAssertEqual(YES, [LYTConfig sharedInstance].ambiguousAutolayoutTestsEnabled);
+    XCTAssertEqual(YES, [LYTConfig sharedInstance].interceptsAutolayoutErrors);
+    XCTAssertEqual(YES, [LYTConfig sharedInstance].accessibilityTestsEnabled);
+    XCTAssertEqual(YES, [LYTConfig sharedInstance].failingTestSnapshotsEnabled);
+
+    NSSet *viewClassesAllowingSubviewErrorsSet = [NSSet setWithObjects:[UITextView class], [UISwitch class], nil];
+    NSSet *viewClassesRequiringAccessibilityLabelsSets = [NSSet setWithObjects:[UIControl class], nil];
+    XCTAssertEqualObjects(viewClassesAllowingSubviewErrorsSet, [LYTConfig sharedInstance].viewClassesAllowingSubviewErrors);
+    XCTAssertEqualObjects(viewClassesRequiringAccessibilityLabelsSets, [LYTConfig sharedInstance].viewClassesRequiringAccessibilityLabels);
+    XCTAssertEqual(1e-5, [LYTConfig sharedInstance].cgFloatEpsilon);
+    XCTAssertEqual(-1, [LYTConfig sharedInstance].snapshotsToSavePerMethod);
 }
 
 @end

--- a/LayoutTestTests/LayoutTestCaseTests/LYTLayoutFailingTestSnapshotRecorderTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LYTLayoutFailingTestSnapshotRecorderTests.m
@@ -1,0 +1,278 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+#import <XCTest/XCTest.h>
+#import "LYTLayoutFailingTestSnapshotRecorder.h"
+#import "LYTConfig.h"
+
+@interface LYTLayoutFailingTestSnapshotRecorderTests : XCTestCase
+
+@property (nonatomic) LYTLayoutFailingTestSnapshotRecorder *recorder;
+
+@end
+
+@implementation LYTLayoutFailingTestSnapshotRecorderTests
+
+- (void)setUp {
+    [super setUp];
+    self.recorder = [[LYTLayoutFailingTestSnapshotRecorder alloc] init];
+}
+
+- (void)tearDown {
+    self.recorder = nil;
+    [super tearDown];
+}
+
+- (void)testStartNewLogDeletesExisitingClassSnapshotDirectory {
+    //Setup directory and file to make sure file is deleted when we start a new log.
+    NSString *currentDirectory = [[NSBundle bundleForClass:self.class] bundlePath];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *classDirectory = [currentDirectory stringByAppendingPathComponent:@"LayoutTestImages/LYTLayoutFailingTestSnapshotRecorderTests"];
+    NSString *testFilePath = [classDirectory stringByAppendingPathComponent:@"testFile.html"];
+    [fileManager createDirectoryAtPath:classDirectory withIntermediateDirectories:YES attributes:nil error:nil];
+    [fileManager createFileAtPath:testFilePath contents:nil attributes:nil];
+
+    [self.recorder startNewLogForClass:self.class];
+    
+    XCTAssertFalse([fileManager fileExistsAtPath:testFilePath]);
+}
+
+- (void)testStartNewLogCreatesIndexHTMLFileWithExpectedContent {
+    [self.recorder startNewLogForClass:self.class];
+    
+    NSString *actualHTML = [self indexHTMLFile];
+    XCTAssertEqualObjects([self expectedStartOfFileHTML], actualHTML);
+}
+
+- (void)testFinishLogAddsExpectedHTMLToIndexFile {
+    [self.recorder startNewLogForClass:self.class];
+    [self.recorder finishLog];
+    
+    NSString *actualHTML = [self indexHTMLFile];
+    NSString *expectedHTML = [NSString stringWithFormat:@"%@%@", [self expectedStartOfFileHTML], [self expectedEndOfFileHTML]];
+    XCTAssertEqualObjects(expectedHTML, actualHTML);
+}
+
+- (void)testSaveImageOfCurrentViewCreatesDirectoryFromInvocationSelectorName {
+    [self.recorder startNewLogForClass:self.class];
+    
+    [self.recorder saveImageOfView:nil withData:nil fromInvocation:self.invocation failureDescription:@""];
+    
+    NSString *directoryPath = [self pathForCurrentInvocation];
+    BOOL isDirectory = NO;
+    BOOL fileExisits = [[NSFileManager defaultManager] fileExistsAtPath:directoryPath isDirectory:&isDirectory];
+    
+    XCTAssertTrue(fileExisits);
+    XCTAssertTrue(isDirectory);
+}
+
+- (void)testSaveImageOfCurrentViewSavesImageToDisk {
+    UIView *testView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 100, 100}];
+    [self.recorder startNewLogForClass:self.class];
+    NSDictionary *data = @{@"key" : @"value"};
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@""];
+    
+    NSString *imageName = [NSString stringWithFormat:@"/Width-100.00_Height-100.00_Data-%lu.png", (unsigned long)data.description.hash];
+    NSString *imagePath = [[self pathForCurrentInvocation] stringByAppendingString:imageName];
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:imagePath]);
+}
+
+- (void)testSaveImageOfCurrentViewWhenViewHasWidthOfZeroDoesNotSaveImage {
+    UIView *testView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 0, 100}];
+    [self.recorder startNewLogForClass:self.class];
+    
+    [self.recorder saveImageOfView:testView withData:nil fromInvocation:self.invocation failureDescription:@""];
+    
+    NSArray *filelist = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[self pathForCurrentInvocation] error:nil];
+    XCTAssertFalse(filelist.count == 1);
+}
+
+- (void)testSaveImageOfCurrentViewWhenViewHasHeightOfZeroDoesNotSaveImage {
+    UIView *testView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 100, 0}];
+    [self.recorder startNewLogForClass:self.class];
+    
+    [self.recorder saveImageOfView:testView withData:nil fromInvocation:self.invocation failureDescription:@""];
+    
+    NSArray *filelist = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[self pathForCurrentInvocation] error:nil];
+    XCTAssertEqual(0, filelist.count);
+}
+
+- (void)testSaveImageOfCurrentViewWhenDataHasSpecialCharactersImageSavedWithExpectedName {
+    UIView *testView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 100, 100}];
+    NSDictionary *data = @{@"key" : @"漢語 ♔ 🚂 ☎ Here are some more special characters ˆ™£‡‹·Ú‹˜ƒª•"};
+    [self.recorder startNewLogForClass:self.class];
+    
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@""];
+    
+    NSString*expectedImageName = [NSString stringWithFormat:@"/Width-100.00_Height-100.00_Data-%lu.png", (unsigned long)data.description.hash];
+    NSString *imagePath = [[self pathForCurrentInvocation] stringByAppendingString:expectedImageName];
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:imagePath]);
+}
+
+- (void)testSaveImageOfCurrentViewWhenDataDescriptionIsOverTwoHunderedCharactersImageSavedWithExpectedName {
+    UIView *testView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 100, 100}];
+    NSDictionary *data = @{@"key" : [self threeHunderedAndSixtyFourCharacterString]};
+    [self.recorder startNewLogForClass:self.class];
+    
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@""];
+    
+    NSString*expectedImageName = [NSString stringWithFormat:@"/Width-100.00_Height-100.00_Data-%lu.png", (unsigned long)data.description.hash];
+    NSString *imagePath = [[self pathForCurrentInvocation] stringByAppendingString:expectedImageName];
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:imagePath]);
+}
+
+- (void)testSaveImageOfCurrentViewWhenCalledTwiceWithSlightlyDifferentDataSavesTwoImages {
+    UIView *testView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 100, 100}];
+    NSDictionary *data = @{@"key" : @"value"};
+    NSDictionary *data1 = @{@"key" : @"value1"};
+    [self.recorder startNewLogForClass:self.class];
+    
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@""];
+    data = @{@"key" : @"value1"};
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@""];
+    
+    
+    NSString*expectedFirstImageName = [NSString stringWithFormat:@"/Width-100.00_Height-100.00_Data-%lu.png", (unsigned long)data.description.hash];
+    NSString *firstImagePath = [[self pathForCurrentInvocation] stringByAppendingString:expectedFirstImageName];
+    NSString*expectedSecondImageName = [NSString stringWithFormat:@"/Width-100.00_Height-100.00_Data-%lu.png", (unsigned long)data1.description.hash];
+    NSString *secondImagePath = [[self pathForCurrentInvocation] stringByAppendingString:expectedSecondImageName];
+    
+    NSArray *filelist = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[self pathForCurrentInvocation] error:nil];
+    XCTAssertEqual(2, filelist.count);
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:firstImagePath]);
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:secondImagePath]);
+}
+
+- (void)testSaveImageWhenConfigHasNumberOfImagesToSaveSetToZeroDoesNotSaveImage {
+    UIView *testView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 100, 100}];
+    NSDictionary *data = @{@"key" : @"value"};
+    [self.recorder startNewLogForClass:self.class];
+    [LYTConfig sharedInstance].snapshotsToSavePerMethod = 0;
+    
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@""];
+    
+    NSArray *filelist = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[self pathForCurrentInvocation] error:nil];
+    XCTAssertEqual(0, filelist.count);
+}
+
+- (void)testSaveImageWhenConfigHasNumberOfImagesToSaveSetToFourOnlySavesFourImages {
+    UIView *testView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 100, 100}];
+    NSDictionary *data = @{@"key" : @"value"};
+    [self.recorder startNewLogForClass:self.class];
+    [LYTConfig sharedInstance].snapshotsToSavePerMethod = 4;
+    
+    //Should be saved
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@""];
+    data = @{@"key1" : @"value"};
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@""];
+    data = @{@"key2" : @"value"};
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@""];
+    data = @{@"key3" : @"value"};
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@""];
+    //
+    
+    //Shoudln't be saved
+    data = @{@"key4" : @"value"};
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@""];
+    //
+    
+    NSArray *filelist = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[self pathForCurrentInvocation] error:nil];
+    XCTAssertEqual(4, filelist.count);
+}
+
+- (void)testSaveImageOfCurrentViewAddsFailureDescriptionImageAndDataToIndexFile {
+    UIView *testView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 100, 100}];
+    NSDictionary *data = @{@"key" : @"value"};
+    [self.recorder startNewLogForClass:self.class];
+    
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@"This is a test failure description"];
+    [self.recorder finishLog];
+    
+    NSString *dataHash = @"";
+#ifdef __LP64__
+    dataHash = @"11921695704359177406";
+#else
+    dataHash = @"1252068542";
+#endif
+    NSString *actualHTML = [self indexHTMLFile];
+    NSString *expectedBodyHTML = [NSString stringWithFormat:@"<TR><TD>This is a test failure description</TD><TD><IMG src='testSaveImageOfCurrentViewAddsFailureDescriptionImageAndDataToIndexFile/Width-100.00_Height-100.00_Data-%@.png' alt='No Image'></TD><TD>{    key = value;}</TD></TR>", dataHash];
+    NSString *expectedHTML = [NSString stringWithFormat:@"%@%@%@", [self expectedStartOfFileHTML], expectedBodyHTML, [self expectedEndOfFileHTML]];
+    XCTAssertEqualObjects(expectedHTML, actualHTML);
+}
+
+- (void)testSaveImageOfCurrentViewWhenViewAndDataAlreadySavedDoesNotReaddFailureDescriptionImageAndDataToIndexFile {
+    UIView *testView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 100, 1000}];
+    NSDictionary *data = @{@"key" : @"value"};
+    [self.recorder startNewLogForClass:self.class];
+    
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@"This is a test failure description"];
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:@"This is a test failure description"];
+    [self.recorder finishLog];
+    
+    NSString *dataHash = @"";
+#ifdef __LP64__
+    dataHash = @"11921695704359177406";
+#else
+    dataHash = @"1252068542";
+#endif
+    NSString *actualHTML = [self indexHTMLFile];
+    NSString *expectedBodyHTML = [NSString stringWithFormat:@"<TR><TD>This is a test failure description</TD><TD><IMG src='testSaveImageOfCurrentViewWhenViewAndDataAlreadySavedDoesNotReaddFailureDescriptionImageAndDataToIndexFile/Width-100.00_Height-1000.00_Data-%@.png' alt='No Image'></TD><TD>{    key = value;}</TD></TR>", dataHash];
+    NSString *expectedHTML = [NSString stringWithFormat:@"%@%@%@", [self expectedStartOfFileHTML], expectedBodyHTML, [self expectedEndOfFileHTML]];
+    XCTAssertEqualObjects(expectedHTML, actualHTML);
+}
+
+- (void)testSaveImageOfCurrentViewWithNilFailureDescriptionAddsBlankDescriptionToIndexFile {
+    UIView *testView = [[UIView alloc] initWithFrame:(CGRect){0, 0, 1000, 100}];
+    NSDictionary *data = @{@"key" : @"value"};
+    [self.recorder startNewLogForClass:self.class];
+    
+    [self.recorder saveImageOfView:testView withData:data fromInvocation:self.invocation failureDescription:nil];
+    [self.recorder finishLog];
+    
+    NSString *dataHash = @"";
+#ifdef __LP64__
+    dataHash = @"11921695704359177406";
+#else
+    dataHash = @"1252068542";
+#endif
+    NSString *actualHTML = [self indexHTMLFile];
+    NSString *expectedBodyHTML = [NSString stringWithFormat:@"<TR><TD></TD><TD><IMG src='testSaveImageOfCurrentViewWithNilFailureDescriptionAddsBlankDescriptionToIndexFile/Width-1000.00_Height-100.00_Data-%@.png' alt='No Image'></TD><TD>{    key = value;}</TD></TR>", dataHash];
+    NSString *expectedHTML = [NSString stringWithFormat:@"%@%@%@", [self expectedStartOfFileHTML], expectedBodyHTML, [self expectedEndOfFileHTML]];
+    XCTAssertEqualObjects(expectedHTML, actualHTML);
+}
+
+- (NSString *)indexHTMLFile {
+    NSString *indexFilePath = [[self classDirectoryPath] stringByAppendingPathComponent:@"index.html"];
+    return [NSString stringWithContentsOfFile:indexFilePath encoding:NSUTF8StringEncoding error:nil];
+}
+
+- (NSString *)classDirectoryPath {
+    NSString *currentDirectory = [[NSBundle bundleForClass:self.class] bundlePath];
+    return [currentDirectory stringByAppendingPathComponent:@"LayoutTestImages/LYTLayoutFailingTestSnapshotRecorderTests"];
+}
+
+- (NSString *)pathForCurrentInvocation {
+    NSString *directoryPath = [self classDirectoryPath];
+    NSString *methodName = NSStringFromSelector((SEL)[self.invocation selector]);
+    return [directoryPath stringByAppendingPathComponent:methodName];
+}
+
+- (NSString *)expectedStartOfFileHTML {
+    return @"<HTML><HEAD></HEAD><BODY><TABLE style='width:100%'><TR><TH>Description</TH><TH>Image</TH><TH>Input Data</TH></TR>";
+}
+
+- (NSString *)expectedEndOfFileHTML {
+    return @"</TABLE></BODY></HTML>";
+}
+
+- (NSString *)threeHunderedAndSixtyFourCharacterString {
+    return @"Very long string. This string is so long that it's longer than I want it to be. Just a really really long string. In fact, it's just long as long can be. I'm just lengthening the longest string by making it longer with more characters. Do you think this is long enough yet? I think so, so I'm going to stop making this long string longer by adding more characters.";
+}
+
+@end

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutReportSnapshotLocationsTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutReportSnapshotLocationsTests.m
@@ -1,0 +1,30 @@
+//
+//  LayoutReportSnapshotLocations.m
+//  LayoutTest
+//
+//  Created by Jock Findlay on 09/02/2016.
+//  Copyright © 2016 LinkedIn. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "LYTLayoutTestCase.h"
+#import "LYTLayoutFailingTestSnapshotRecorder.h"
+
+@interface LYTLayoutFailingTestSnapshotRecorder ()
+@property (nonatomic) NSMutableSet *failingTestsSnapshotFolders;
+- (void)testCase:(XCTestCase *)testCase didFailWithDescription:(NSString *)description inFile:(nullable NSString *)filePath atLine:(NSUInteger)lineNumber;
+@end
+
+@interface LayoutReportSnapshotLocationsTests : LYTLayoutTestCase
+@end
+
+@implementation LayoutReportSnapshotLocationsTests
+
+- (void)testAllLocationsOfReportsAreLoggedToConsoleAtTheEnd {
+    [[LYTLayoutFailingTestSnapshotRecorder sharedInstance] testCase:self didFailWithDescription:@"" inFile:@"File1" atLine:0];
+    NSString *expectedPathContaining = @"LayoutTestImages/LayoutReportSnapshotLocationsTests/index.html";
+    NSString *actualPath = [LYTLayoutFailingTestSnapshotRecorder sharedInstance].failingTestsSnapshotFolders.anyObject;
+    XCTAssertTrue([actualPath containsString:expectedPathContaining]);
+}
+
+@end

--- a/LayoutTestTests/LayoutTestCaseTests/SwiftLYTLayoutFailingTestSnapshotRecorderTests.swift
+++ b/LayoutTestTests/LayoutTestCaseTests/SwiftLYTLayoutFailingTestSnapshotRecorderTests.swift
@@ -1,0 +1,31 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+import XCTest
+import LayoutTest
+
+class SwiftLYTLayoutFailingTestSnapshotRecorderTests: XCTestCase {
+    
+    func testStartNewLogDeletesExisitingClassSnapshotDirectory() {
+        let fileManager = NSFileManager.defaultManager()
+        let currentDirectory = NSBundle(forClass:self.dynamicType).bundlePath
+        let classDirectory = currentDirectory.stringByAppendingString("/LayoutTestImages/SwiftLYTLayoutFailingTestSnapshotRecorderTests")
+        let testFilePath = classDirectory.stringByAppendingString("/testFile.html")
+        do {
+            try fileManager.createDirectoryAtPath(classDirectory, withIntermediateDirectories: true, attributes: nil)
+        } catch{}
+        fileManager.createFileAtPath(testFilePath, contents: nil, attributes: nil)
+        
+        let recorder = LYTLayoutFailingTestSnapshotRecorder()
+        recorder.startNewLogForClass(self.dynamicType)
+        
+        XCTAssertFalse(fileManager.fileExistsAtPath(testFilePath))
+    }
+    
+}

--- a/SampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		61A305E41C12583100CB3FEC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A305E31C12583100CB3FEC /* AppDelegate.swift */; };
 		61A305EB1C12583100CB3FEC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 61A305EA1C12583100CB3FEC /* Assets.xcassets */; };
 		61A305EE1C12583100CB3FEC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61A305EC1C12583100CB3FEC /* LaunchScreen.storyboard */; };
-		61A306041C12587100CB3FEC /* SampleTableViewCellLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A306031C12587100CB3FEC /* SampleTableViewCellLayoutTests.swift */; };
 		61A306091C12588700CB3FEC /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A306051C12588700CB3FEC /* HomeViewController.swift */; };
 		61A3060A1C12588700CB3FEC /* HomeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 61A306061C12588700CB3FEC /* HomeViewController.xib */; };
 		61A3060B1C12588700CB3FEC /* SampleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A306071C12588700CB3FEC /* SampleTableViewCell.swift */; };
@@ -23,6 +22,10 @@
 		61F42D7E1C18878700A21677 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61F42D7C1C18878700A21677 /* LaunchScreen.storyboard */; };
 		80D929B7BEDDE2B3BB220B59 /* Pods_CatalogSample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F204CD35FFC3C2EC6A56E828 /* Pods_CatalogSample.framework */; };
 		AF642C19C9DA1CBDF87E8127 /* Pods_SampleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20C92A33C23683C87FF5EC96 /* Pods_SampleApp.framework */; };
+		C56317EB1C63589900A8E8BA /* SampleFailingLayoutTestsWithSnapshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56317EA1C63589900A8E8BA /* SampleFailingLayoutTestsWithSnapshots.swift */; };
+		C56317ED1C6358F800A8E8BA /* SampleFailingView.xib in Resources */ = {isa = PBXBuildFile; fileRef = C56317EC1C6358F800A8E8BA /* SampleFailingView.xib */; };
+		C56317EF1C63596400A8E8BA /* SampleFailingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56317EE1C63596400A8E8BA /* SampleFailingView.swift */; };
+		C5CE8F9E1C621E2500250812 /* SampleTableViewCellLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A306031C12587100CB3FEC /* SampleTableViewCellLayoutTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +63,9 @@
 		61F42D7D1C18878700A21677 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		61F42D7F1C18878700A21677 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6E137A0CBD23A2BC2E834EDF /* Pods-SampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp.debug.xcconfig"; sourceTree = "<group>"; };
+		C56317EA1C63589900A8E8BA /* SampleFailingLayoutTestsWithSnapshots.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleFailingLayoutTestsWithSnapshots.swift; sourceTree = "<group>"; };
+		C56317EC1C6358F800A8E8BA /* SampleFailingView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SampleFailingView.xib; sourceTree = "<group>"; };
+		C56317EE1C63596400A8E8BA /* SampleFailingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleFailingView.swift; sourceTree = "<group>"; };
 		C8E3A016ED97012DB64C99EA /* Pods-SampleAppTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleAppTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SampleAppTests/Pods-SampleAppTests.release.xcconfig"; sourceTree = "<group>"; };
 		F204CD35FFC3C2EC6A56E828 /* Pods_CatalogSample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CatalogSample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -138,6 +144,8 @@
 				61A305EA1C12583100CB3FEC /* Assets.xcassets */,
 				61A305EC1C12583100CB3FEC /* LaunchScreen.storyboard */,
 				61A305EF1C12583100CB3FEC /* Info.plist */,
+				C56317EC1C6358F800A8E8BA /* SampleFailingView.xib */,
+				C56317EE1C63596400A8E8BA /* SampleFailingView.swift */,
 			);
 			path = SampleApp;
 			sourceTree = "<group>";
@@ -147,6 +155,7 @@
 			children = (
 				61A306031C12587100CB3FEC /* SampleTableViewCellLayoutTests.swift */,
 				61A305FA1C12583100CB3FEC /* Info.plist */,
+				C56317EA1C63589900A8E8BA /* SampleFailingLayoutTestsWithSnapshots.swift */,
 			);
 			path = SampleAppTests;
 			sourceTree = "<group>";
@@ -286,6 +295,7 @@
 				61A305EE1C12583100CB3FEC /* LaunchScreen.storyboard in Resources */,
 				61A3060C1C12588700CB3FEC /* SampleTableViewCell.xib in Resources */,
 				61A305EB1C12583100CB3FEC /* Assets.xcassets in Resources */,
+				C56317ED1C6358F800A8E8BA /* SampleFailingView.xib in Resources */,
 				61A3060A1C12588700CB3FEC /* HomeViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -453,6 +463,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61A3060B1C12588700CB3FEC /* SampleTableViewCell.swift in Sources */,
+				C56317EF1C63596400A8E8BA /* SampleFailingView.swift in Sources */,
 				61A305E41C12583100CB3FEC /* AppDelegate.swift in Sources */,
 				61A306091C12588700CB3FEC /* HomeViewController.swift in Sources */,
 			);
@@ -462,7 +473,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				61A306041C12587100CB3FEC /* SampleTableViewCellLayoutTests.swift in Sources */,
+				C56317EB1C63589900A8E8BA /* SampleFailingLayoutTestsWithSnapshots.swift in Sources */,
+				C5CE8F9E1C621E2500250812 /* SampleTableViewCellLayoutTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SampleApp/SampleApp/Base.lproj/LaunchScreen.storyboard
+++ b/SampleApp/SampleApp/Base.lproj/LaunchScreen.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -15,7 +16,6 @@
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                 </viewController>

--- a/SampleApp/SampleApp/SampleFailingView.swift
+++ b/SampleApp/SampleApp/SampleFailingView.swift
@@ -22,6 +22,6 @@ public class SampleFailingView: UIView {
 
     func setup(json: [NSObject: AnyObject]) {
         label.text = json["text"] as? String
-        button.titleLabel?.text = json["buttonText"] as? String
+        button.setTitle(json["buttonText"] as? String, forState: .Normal)
     }
 }

--- a/SampleApp/SampleApp/SampleFailingView.swift
+++ b/SampleApp/SampleApp/SampleFailingView.swift
@@ -1,0 +1,27 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+import UIKit
+
+public class SampleFailingView: UIView {
+
+    private static let nibName = "SampleFailingView"
+    
+    @IBOutlet weak var label: UILabel!
+    @IBOutlet weak var button: UIButton!
+    
+    class func loadFromNib() -> SampleFailingView {
+        return NSBundle.mainBundle().loadNibNamed(SampleFailingView.nibName, owner: nil, options: nil)[0] as! SampleFailingView
+    }
+
+    func setup(json: [NSObject: AnyObject]) {
+        label.text = json["text"] as? String
+        button.titleLabel?.text = json["buttonText"] as? String
+    }
+}

--- a/SampleApp/SampleApp/SampleFailingView.xib
+++ b/SampleApp/SampleApp/SampleFailingView.xib
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="SampleFailingView" customModule="SampleApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="554" height="38"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A Beautiful Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L50-fe-ui2">
+                    <rect key="frame" x="8" y="8" width="129" height="21"/>
+                    <accessibility key="accessibilityConfiguration" hint="A Beautiful Label" identifier="ABeautifulLabel" label="A Beautiful Label"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="W6R-Y4-kjN">
+                    <rect key="frame" x="422" y="8" width="124" height="30"/>
+                    <accessibility key="accessibilityConfiguration" hint="A Beautiful Button" identifier="ABeautifulButton" label="A Beautiful Button"/>
+                    <state key="normal" title="A Beautiful Button"/>
+                </button>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="W6R-Y4-kjN" secondAttribute="trailing" constant="8" id="AkC-5G-11k"/>
+                <constraint firstItem="L50-fe-ui2" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="NKJ-55-UNL"/>
+                <constraint firstItem="W6R-Y4-kjN" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="VX6-ly-DfD"/>
+                <constraint firstItem="L50-fe-ui2" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="cHm-B9-zzB"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="button" destination="W6R-Y4-kjN" id="QV0-ml-QjK"/>
+                <outlet property="label" destination="L50-fe-ui2" id="pZp-hp-52r"/>
+            </connections>
+            <point key="canvasLocation" x="224" y="396"/>
+        </view>
+    </objects>
+</document>

--- a/SampleApp/SampleApp/SampleTableViewCell.xib
+++ b/SampleApp/SampleApp/SampleTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1509" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
@@ -12,7 +12,7 @@
             <rect key="frame" x="0.0" y="0.0" width="481" height="96"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="481" height="95.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="481" height="95"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="04P-sS-pqc">
@@ -22,14 +22,14 @@
                             <constraint firstAttribute="width" constant="30" id="boS-NT-y1U"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vmb-2m-FXb">
-                        <rect key="frame" x="45.5" y="8" width="347.5" height="71.5"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vmb-2m-FXb">
+                        <rect key="frame" x="46" y="8" width="348" height="72"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ad0-Q9-38q">
-                        <rect key="frame" x="393" y="8" width="80" height="71.5"/>
+                    <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ad0-Q9-38q">
+                        <rect key="frame" x="393" y="8" width="80" height="72"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="80" id="m95-cV-UWO"/>
                         </constraints>

--- a/SampleApp/SampleAppTests/SampleFailingLayoutTestsWithSnapshots.swift
+++ b/SampleApp/SampleAppTests/SampleFailingLayoutTestsWithSnapshots.swift
@@ -1,0 +1,43 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+import XCTest
+@testable import SampleApp
+import LayoutTest
+import LayoutTestBase
+
+class SampleFailingLayoutTestsWithSnapshots : LayoutTestCase {
+    
+    func testSampleFailingViewWithSnapshots() {
+        runLayoutTests() { (view: SampleFailingView, data: [NSObject: AnyObject], context: Any?) in
+            // Expecting one of the auto-layout tests to fail when the really long string causes the label to overlap with the button
+        }
+    }
+}
+
+extension SampleFailingView : LYTViewProvider {
+    public class func dataSpecForTest() -> [NSObject: AnyObject] {
+        return [
+            "text": LYTStringValues(),
+            "buttonText": LYTStringValues()
+        ]
+    }
+    
+    public class func viewForData(data: [NSObject: AnyObject], reuseView: UIView?, size: LYTViewSize?, context: AutoreleasingUnsafeMutablePointer<AnyObject?>) -> UIView {
+        let view = reuseView as? SampleFailingView ?? SampleFailingView.loadFromNib()
+        view.setup(data)
+        return view
+    }
+    
+    public class func sizesForView() -> [LYTViewSize] {
+        return [
+            LYTViewSize(width: 300),
+        ]
+    }
+}


### PR DESCRIPTION
Snapshots will be saved for any failing test.
- Snapshots are saved into the derived data folder for the current simulator.
- Snapshots are saved in the folder structure LayoutTestImages/{CLASS-NAME}/{METHOD-NAME}/
- Snapshots are saved in the format Width-{VIEW-WIDth}_Height-{VIEW-HEIGHT}_{HASH-OF-FAILING-DATA-DESCRIPTION}.png
- Snapshots are logged to a index.html file for each class which includes the failure reason, image and data that was passed to the view.
- The paths to the failing test index.html files are logged to the console at the end of the test bundle run.
- Snapshots can be disabled using the LYTConfig
- Snapshots can be limited per method using the LYTConfig