### PR TITLE
Adding XML escaping.

### DIFF
--- a/LayoutTest/TestCase/LYTLayoutFailingTestSnapshotRecorder.m
+++ b/LayoutTest/TestCase/LYTLayoutFailingTestSnapshotRecorder.m
@@ -21,6 +21,26 @@ void SimpleLog(NSString *format, ...) {
     [[NSFileHandle fileHandleWithStandardOutput] writeData:[formattedString dataUsingEncoding:NSNEXTSTEPStringEncoding]];
 }
 
+@interface NSString (XMLEscape)
+
+- (NSString *)lyt_stringByAddingXMLEscaping;
+
+@end
+
+@implementation NSString (XMLEscape)
+
+- (NSString *)lyt_stringByAddingXMLEscaping {
+    NSString *string = [self stringByReplacingOccurrencesOfString:@"&" withString:@"&amp;"];
+    string = [string stringByReplacingOccurrencesOfString:@"<" withString:@"&lt;"];
+    string = [string stringByReplacingOccurrencesOfString:@">" withString:@"&gt;"];
+    string = [string stringByReplacingOccurrencesOfString:@"'" withString:@"&#39;"];
+    string = [string stringByReplacingOccurrencesOfString:@"\"" withString:@"&quot;"];
+    return string;
+}
+
+@end
+
+
 @interface LYTLayoutFailingTestSnapshotRecorder ()
 
 @property (nonatomic) Class invocationClass;
@@ -138,7 +158,7 @@ void SimpleLog(NSString *format, ...) {
     
     NSString *filePath = [self indexHTMLFilePath];
     NSString *imagePath = [NSString stringWithFormat:@"%@/%@", [self methodNameForInvocation:invocation], [self nameForImageWithWidth:width height:height data:data]];
-    NSString *errorHTML = [NSString stringWithFormat:@"<TR><TD>%@</TD><TD><IMG src='%@' alt='No Image'></TD><TD>%@</TD></TR>", description, imagePath, data.description];
+    NSString *errorHTML = [NSString stringWithFormat:@"<TR><TD>%@</TD><TD><IMG src='%@' alt='No Image'></TD><TD>%@</TD></TR>", [description lyt_stringByAddingXMLEscaping], imagePath, data.description];
     errorHTML = [errorHTML stringByReplacingOccurrencesOfString:@"\n" withString:@""];
     NSFileHandle *fileHandler = [NSFileHandle fileHandleForUpdatingAtPath:filePath];
     

--- a/LayoutTest/TestCase/LYTLayoutFailingTestSnapshotRecorder.m
+++ b/LayoutTest/TestCase/LYTLayoutFailingTestSnapshotRecorder.m
@@ -200,7 +200,10 @@ void SimpleLog(NSString *format, ...) {
 }
 
 - (NSString *)commonRootPathForInvocationClass:(Class)classForRoot {
-    NSString *currentDirectory = [[NSBundle bundleForClass:classForRoot] bundlePath];
+    NSString *currentDirectory = [NSProcessInfo processInfo].environment[@"LYT_FAILING_TEST_SNAPSHOT_DIR"];
+    if (!currentDirectory) {
+        currentDirectory = [[NSBundle bundleForClass:classForRoot] bundlePath];
+    }
     NSString *className = NSStringFromClass(classForRoot);
     //Check incase the class name includes a ".", if so we the actual class name will be everything after the "."
     if ([className containsString:@"."]) {

--- a/LayoutTest/TestCase/LYTLayoutTestCase.m
+++ b/LayoutTest/TestCase/LYTLayoutTestCase.m
@@ -133,7 +133,8 @@ NS_ASSUME_NONNULL_BEGIN
     view = [LYTLayoutTestCase viewForSubviewTesting:view];
 
     [view lyt_recursivelyTraverseViewHierarchyWithStop:^(UIView *subview, BOOL *stopBranch) {
-        if ([LYTLayoutTestCase class:[subview class] includedInSet:self.viewClassesAllowingSubviewErrors]) {
+        if ([LYTLayoutTestCase class:[subview class] includedInSet:self.viewClassesAllowingSubviewErrors] ||
+            subview.hidden) {
             *stopBranch = YES;
         } else {
             [self runSubviewsOverlapTestsWithSubview:subview view:view];

--- a/LayoutTestBase/Core/Testers/LYTLayoutPropertyTester.m
+++ b/LayoutTestBase/Core/Testers/LYTLayoutPropertyTester.m
@@ -113,7 +113,7 @@
                                 limitResults:(LYTTesterLimitResults)limitResults
                                        block:(void(^)(UIView *view, NSDictionary *data, id context))validation {
     NSArray *sizes = [self viewSizesForProviderProtocol:viewProvider limitResults:limitResults];
-    if (sizes) {
+    if (sizes.count) {
         for (LYTViewSize *size in sizes) {
             reuseView = [self runSingleTestWithProviderProtocol:viewProvider
                                                            data:data

--- a/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.m
+++ b/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.m
@@ -21,7 +21,7 @@
     CGFloat epsilon = [LYTConfig sharedInstance].cgFloatEpsilon;
 
     if ([self lyt_leftToRight]) {
-        return self.bounds.size.width <= otherViewBounds.origin.x + epsilon;
+        return self.bounds.origin.x + self.bounds.size.width <= otherViewBounds.origin.x + epsilon;
     } else {
         return self.bounds.origin.x + epsilon >= otherViewBounds.origin.x + otherViewBounds.size.width;
     }
@@ -35,7 +35,7 @@
     CGRect otherViewBounds = [self convertRect:otherView.bounds fromView:otherView];
     CGFloat epsilon = [LYTConfig sharedInstance].cgFloatEpsilon;
 
-    return self.bounds.size.height <= otherViewBounds.origin.y + epsilon;
+    return self.bounds.origin.y + self.bounds.size.height <= otherViewBounds.origin.y + epsilon;
 }
 
 - (BOOL)lyt_below:(UIView *)otherView {


### PR DESCRIPTION
index.html for failing tests can not show UIView constraint conflicts correctly, because there's a '<' in it.
For example, the HTML shows
`failed - Bottom right corner of > overlaps upper left corner of >. If this is intentional, you should add one of the views to viewsAllowingOverlap.	`
instead of 
`failed - Bottom right corner of <UIView: 0x7fc2a9a78960; frame = (12 10; 351 101.667); layer = <CALayer: 0x7fc2a9a16610>> overlaps upper left corner of <UIImageView: 0x7fc2a9a0fa40; frame = (105.667 87.3333; 13 13); opaque = NO; userInteractionEnabled = NO; layer = <CALayer: 0x7fc2a9a79c00>>. If this is intentional, you should add one of the views to viewsAllowingOverlap.`

This pull request add methods to make specified XML/HTML entities escaped.