### PR TITLE
Allowing UIButton bckground image overlap.

### DIFF
--- a/LayoutTest/TestCase/LYTLayoutTestCase.m
+++ b/LayoutTest/TestCase/LYTLayoutTestCase.m
@@ -147,6 +147,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)runSubviewsOverlapTestsWithSubview:(UIView *)subview view:(UIView *)view {
     if (self.viewOverlapTestsEnabled) {
+        NSArray *viewsAllowingOverlap = [LYTLayoutTestCase subviewsAllowingOverlapInView:subview];
+        if (viewsAllowingOverlap.count > 0) {
+            [self.viewsAllowingOverlap addObjectsFromArray:viewsAllowingOverlap];
+        }
+        
         [subview lyt_assertNoSubviewsOverlap:^(NSString *error, UIView *view1, UIView *view2) {
             if (![self.viewsAllowingOverlap containsObject:view1] &&
                 ![self.viewsAllowingOverlap containsObject:view2] &&
@@ -251,6 +256,18 @@ NS_ASSUME_NONNULL_BEGIN
     } else {
         return [self firstSuperviewWithAccessibilityLabel:view.superview];
     }
+}
+
++ (NSArray *)subviewsAllowingOverlapInView:(UIView *)view {
+    if ([view isKindOfClass:[UIButton class]]) {
+        for (UIView *subview in view.subviews) {
+            if ([subview isKindOfClass:[UIImageView class]] &&
+                ((UIImageView *)subview).image == [((UIButton *)view) currentBackgroundImage]) {
+                return @[subview];
+            }
+        }
+    }
+    return nil;
 }
 
 @end

--- a/LayoutTestTests/Helpers/UnitTestViews.h
+++ b/LayoutTestTests/Helpers/UnitTestViews.h
@@ -36,4 +36,6 @@
 
 + (UIViewWithLabel *)viewWithLongStringOverlappingLabel;
 
++ (UIButton *)buttonWithBackgroundImage;
+
 @end

--- a/LayoutTestTests/Helpers/UnitTestViews.m
+++ b/LayoutTestTests/Helpers/UnitTestViews.m
@@ -182,6 +182,16 @@
     return superview;
 }
 
++ (UIButton *)buttonWithBackgroundImage {
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+    button.frame = CGRectMake(0, 0, 44, 44);
+    [button setBackgroundImage:[[UIImage alloc] init] forState:UIControlStateNormal];
+    [button setTitle:@"Button" forState:UIControlStateNormal];
+    [button setImage:[[UIImage alloc] init] forState:UIControlStateNormal];
+    button.accessibilityLabel = @"Button with background image.";
+    return button;
+}
+
 @end
 
 /**

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseOverlapTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseOverlapTests.m
@@ -26,7 +26,7 @@
         timesCalled++;
     }];
 
-    XCTAssertEqual(timesCalled, 3);
+    XCTAssertEqual(timesCalled, 4);
     // We should have failed once for the view that overlaps
     XCTAssertEqual(self.testFailures, 1);
 }
@@ -39,7 +39,7 @@
         view.subviews[0].hidden = YES;
     }];
 
-    XCTAssertEqual(timesCalled, 3);
+    XCTAssertEqual(timesCalled, 4);
     XCTAssertEqual(self.testFailures, 0);
 }
 
@@ -51,7 +51,7 @@
         [self.viewsAllowingOverlap addObject:view.subviews[0]];
     }];
 
-    XCTAssertEqual(timesCalled, 3);
+    XCTAssertEqual(timesCalled, 4);
     XCTAssertEqual(self.testFailures, 0);
 }
 
@@ -69,7 +69,7 @@
         }
     }];
 
-    XCTAssertEqual(timesCalled, 3);
+    XCTAssertEqual(timesCalled, 4);
     // This will fail multiple times for a UISwitch because it has many overlapping subviews
     XCTAssertTrue(self.testFailures > 0);
 
@@ -91,7 +91,8 @@
              @"view": [[LYTDataValues alloc] initWithValues:@[
                                                                    [UnitTestViews viewWithNoProblems],
                                                                    [UnitTestViews viewWithOverlappingViews],
-                                                                   [UnitTestViews viewWithUISwitchSubview]
+                                                                   [UnitTestViews viewWithUISwitchSubview],
+                                                                   [UnitTestViews buttonWithBackgroundImage]
                                                                    ]]
              };
 }


### PR DESCRIPTION
Find UIButton's private `backgroundImageView` and add it into `self.viewsAllowingOverlap`. Solving testing failure: `Bottom right corner of <UIImageView: 0x7fb8c3d9dba0; frame = (0 0; 44 44); clipsToBounds = YES; opaque = NO; userInteractionEnabled = NO; layer = <CALayer: 0x7fb8c3d9cd80>> overlaps upper left corner of <UIButtonLabel: 0x7fb8c61521c0; frame = (4.33333 11.3333; 35.6667 21.6667); text = 'Button'; opaque = NO; userInteractionEnabled = NO; layer = <_UILabelLayer: 0x7fb8c61555a0>>. If this is intentional, you should add one of the views to viewsAllowingOverlap.`