### PR TITLE
restore from_center functionality

### DIFF
--- a/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.h
+++ b/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.h
@@ -28,13 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Version of lyt_before that takes a fromCenter param. If fromCenter is YES, the comparison starts from the center of the view rather than the
  edge, allowing an overlap of up to half of the view. So for example, if this view is at x=0 with a width=10, and another view is at x=6, width=10,
- the function will return YES if fromCenter==YES, NO otherwise. The function honors the epsilon vlaue and right-to-left.
+ the function will return YES if fromCenter==YES, NO otherwise. The function honors the epsilon value and right-to-left.
  
  \param otherView The view you want to compare to. It does not need to have the same superview, but MUST share some ancestor view.
  \param fromCenter If YES, allow an overlap up to the center of otherView. If NO, behavior is the same as without the param
  \returns True if the view is laid out before another view, allowing for an overlap up to the center if fromCenter is YES.
  */
-- (BOOL)lyt_before:(UIView *)otherView fromCenter:(BOOL)fromCenter NS_SWIFT_NAME(before(_:_:));
+- (BOOL)lyt_before:(UIView *)otherView fromCenter:(BOOL)fromCenter NS_SWIFT_NAME(before(_:fromCenter:));
 
 /**
  Returns whether a view is after another view on the horizontal axis. It returns false if they are overlapping in any way.
@@ -51,13 +51,13 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Version of lyt_after that takes a fromCenter param. If fromCenter is YES, the comparison starts from the center of the view rather than the
  edge, allowing an overlap of up to half of the view. So for example, if this view is at x=6 with a width=10, and another view is at x=0, width=10,
- the function will return YES if fromCenter==YES, NO otherwise. The function honors the epsilon vlaue and right-to-left.
+ the function will return YES if fromCenter==YES, NO otherwise. The function honors the epsilon value and right-to-left.
  
  \param otherView The view you want to compare to. It does not need to have the same superview, but MUST share some ancestor view.
  \param fromCenter If YES, allow an overlap up to the center of otherView. If NO, behavior is the same as without the param
  \returns True if the view is laid out before another view, allowing for an overlap up to the center if fromCenter is YES.
  */
-- (BOOL)lyt_after:(UIView *)otherView : (BOOL)fromCenter NS_SWIFT_NAME(after(_:_:));
+- (BOOL)lyt_after:(UIView *)otherView fromCenter:(BOOL)fromCenter NS_SWIFT_NAME(after(_:fromCenter:));
 
 /**
  Returns whether a view is above another view on the vertical axis. It returns false if they are overlapping in any way.

--- a/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.h
+++ b/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.h
@@ -26,6 +26,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)lyt_before:(UIView *)otherView NS_SWIFT_NAME(before(_:));
 
 /**
+ Version of lyt_before that takes a fromCenter param. If fromCenter is YES, the comparison starts from the center of the view rather than the
+ edge, allowing an overlap of up to half of the view. So for example, if this view is at x=0 with a width=10, and another view is at x=6, width=10,
+ the function will return YES if fromCenter==YES, NO otherwise. The function honors the epsilon vlaue and right-to-left.
+ 
+ \param otherView The view you want to compare to. It does not need to have the same superview, but MUST share some ancestor view.
+ \param fromCenter If YES, allow an overlap up to the center of otherView. If NO, behavior is the same as without the param
+ \returns True if the view is laid out before another view, allowing for an overlap up to the center if fromCenter is YES.
+ */
+- (BOOL)lyt_before:(UIView *)otherView fromCenter:(BOOL)fromCenter NS_SWIFT_NAME(before(_:_:));
+
+/**
  Returns whether a view is after another view on the horizontal axis. It returns false if they are overlapping in any way.
  It uses [UIApplication sharedApplication].userInterfaceLayoutDirection to determine what after means. If we are in a right-to-left language (such as 
  Arabic), then after means it must be on the left hand side. Therefore, you can use this to verify your right-to-left behavior.
@@ -36,6 +47,17 @@ NS_ASSUME_NONNULL_BEGIN
  \returns True if the view is laid out after another view.
  */
 - (BOOL)lyt_after:(UIView *)otherView NS_SWIFT_NAME(after(_:));
+
+/**
+ Version of lyt_after that takes a fromCenter param. If fromCenter is YES, the comparison starts from the center of the view rather than the
+ edge, allowing an overlap of up to half of the view. So for example, if this view is at x=6 with a width=10, and another view is at x=0, width=10,
+ the function will return YES if fromCenter==YES, NO otherwise. The function honors the epsilon vlaue and right-to-left.
+ 
+ \param otherView The view you want to compare to. It does not need to have the same superview, but MUST share some ancestor view.
+ \param fromCenter If YES, allow an overlap up to the center of otherView. If NO, behavior is the same as without the param
+ \returns True if the view is laid out before another view, allowing for an overlap up to the center if fromCenter is YES.
+ */
+- (BOOL)lyt_after:(UIView *)otherView : (BOOL)fromCenter NS_SWIFT_NAME(after(_:_:));
 
 /**
  Returns whether a view is above another view on the vertical axis. It returns false if they are overlapping in any way.

--- a/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.m
+++ b/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.m
@@ -27,8 +27,33 @@
     }
 }
 
+- (BOOL)lyt_before:(UIView *)otherView fromCenter:(BOOL)fromCenter {
+    CGRect otherViewBounds = [self convertRect:otherView.bounds fromView:otherView];
+    CGFloat epsilon = [LYTConfig sharedInstance].cgFloatEpsilon;
+    
+    if ([self lyt_leftToRight]) {
+        if (fromCenter) {
+            return self.center.x <= otherViewBounds.origin.x + epsilon;
+        }
+        else {
+            return self.bounds.origin.x + self.bounds.size.width <= otherViewBounds.origin.x + epsilon;
+       }
+    } else {
+        if (fromCenter) {
+            return self.bounds.origin.x + epsilon >= (otherViewBounds.origin.x + otherViewBounds.size.width/2);
+        }
+        else {
+            return self.bounds.origin.x + epsilon >= otherViewBounds.origin.x + otherViewBounds.size.width;
+        }
+    }
+}
+
 - (BOOL)lyt_after:(UIView *)otherView {
     return [otherView lyt_before:self];
+}
+
+- (BOOL)lyt_after:(UIView *)otherView fromCenter:(BOOL)fromCenter {
+    return [otherView lyt_before:self fromCenter:fromCenter];
 }
 
 - (BOOL)lyt_above:(UIView *)otherView {

--- a/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.m
+++ b/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.m
@@ -17,14 +17,7 @@
 #pragma mark - Frames
 
 - (BOOL)lyt_before:(UIView *)otherView {
-    CGRect otherViewBounds = [self convertRect:otherView.bounds fromView:otherView];
-    CGFloat epsilon = [LYTConfig sharedInstance].cgFloatEpsilon;
-
-    if ([self lyt_leftToRight]) {
-        return self.bounds.origin.x + self.bounds.size.width <= otherViewBounds.origin.x + epsilon;
-    } else {
-        return self.bounds.origin.x + epsilon >= otherViewBounds.origin.x + otherViewBounds.size.width;
-    }
+    return [otherView lyt_before:self fromCenter:NO];
 }
 
 - (BOOL)lyt_before:(UIView *)otherView fromCenter:(BOOL)fromCenter {
@@ -34,15 +27,13 @@
     if ([self lyt_leftToRight]) {
         if (fromCenter) {
             return self.center.x <= otherViewBounds.origin.x + epsilon;
-        }
-        else {
+        } else {
             return self.bounds.origin.x + self.bounds.size.width <= otherViewBounds.origin.x + epsilon;
        }
     } else {
         if (fromCenter) {
             return self.bounds.origin.x + epsilon >= (otherViewBounds.origin.x + otherViewBounds.size.width/2);
-        }
-        else {
+        } else {
             return self.bounds.origin.x + epsilon >= otherViewBounds.origin.x + otherViewBounds.size.width;
         }
     }

--- a/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.m
+++ b/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.m
@@ -17,7 +17,7 @@
 #pragma mark - Frames
 
 - (BOOL)lyt_before:(UIView *)otherView {
-    return [otherView lyt_before:self fromCenter:NO];
+    return [self lyt_before:otherView fromCenter:NO];
 }
 
 - (BOOL)lyt_before:(UIView *)otherView fromCenter:(BOOL)fromCenter {

--- a/LayoutTestTests/FrameComparisonTests.m
+++ b/LayoutTestTests/FrameComparisonTests.m
@@ -21,7 +21,6 @@
 @property (nonatomic, strong) LanguageChangingView *superview;
 @property (nonatomic, strong) LanguageChangingView *innerSubview1;
 @property (nonatomic, strong) LanguageChangingView *innerSubview2;
-
 @end
 
 static BOOL isLeftToRight = YES;
@@ -52,6 +51,8 @@ static BOOL isLeftToRight = YES;
     XCTAssertTrue([self.innerSubview1 lyt_before:self.innerSubview2]);
     self.innerSubview1.lyt_left = 0.0000001;
     XCTAssertTrue([self.innerSubview1 lyt_before:self.innerSubview2]);
+    self.innerSubview1.lyt_left = 1;
+    XCTAssertTrue([self.innerSubview1 lyt_before:self.innerSubview2 fromCenter:YES]);
 
     // Failure expected
 
@@ -59,6 +60,10 @@ static BOOL isLeftToRight = YES;
     XCTAssertFalse([self.innerSubview1 lyt_before:self.innerSubview2]);
     self.innerSubview1.lyt_left = 0;
     XCTAssertFalse([self.innerSubview2 lyt_before:self.innerSubview1]);
+    self.innerSubview1.lyt_left = 3;
+    XCTAssertFalse([self.innerSubview1 lyt_before:self.innerSubview2 fromCenter:YES]);
+    self.innerSubview1.lyt_left = 1;
+    XCTAssertFalse([self.innerSubview1 lyt_before:self.innerSubview2 fromCenter:NO]);
 }
 
 - (void)testBeforeRightToLeft {
@@ -72,6 +77,8 @@ static BOOL isLeftToRight = YES;
     XCTAssertTrue([self.innerSubview2 lyt_before:self.innerSubview1]);
     self.innerSubview2.lyt_left = 4.999999;
     XCTAssertTrue([self.innerSubview2 lyt_before:self.innerSubview1]);
+    self.innerSubview2.lyt_left = 8;
+    XCTAssertTrue([self.innerSubview2 lyt_before:self.innerSubview1 fromCenter:YES]);
 
     // Failure expected
 
@@ -79,6 +86,11 @@ static BOOL isLeftToRight = YES;
     XCTAssertFalse([self.innerSubview1 lyt_before:self.innerSubview2]);
     self.innerSubview2.lyt_left = 5;
     XCTAssertFalse([self.innerSubview1 lyt_before:self.innerSubview2]);
+    self.innerSubview2.lyt_left = 8;
+    XCTAssertFalse([self.innerSubview1 lyt_before:self.innerSubview2 fromCenter:YES]);
+    self.innerSubview2.lyt_left = 4;
+    XCTAssertFalse([self.innerSubview2 lyt_before:self.innerSubview1 fromCenter:NO]);
+
 }
 
 #pragma mark - After
@@ -92,6 +104,8 @@ static BOOL isLeftToRight = YES;
     XCTAssertTrue([self.innerSubview2 lyt_after:self.innerSubview1]);
     self.innerSubview2.lyt_left = 4.999999;
     XCTAssertTrue([self.innerSubview2 lyt_after:self.innerSubview1]);
+    self.innerSubview2.lyt_left = 4;
+    XCTAssertTrue([self.innerSubview2 lyt_after:self.innerSubview1 fromCenter:TRUE]);
 
     // Failure expected
 
@@ -99,6 +113,10 @@ static BOOL isLeftToRight = YES;
     XCTAssertFalse([self.innerSubview1 lyt_after:self.innerSubview2]);
     self.innerSubview2.lyt_left = 5;
     XCTAssertFalse([self.innerSubview1 lyt_after:self.innerSubview2]);
+    self.innerSubview2.lyt_left = 2;
+    XCTAssertFalse([self.innerSubview1 lyt_after:self.innerSubview2 fromCenter:YES]);
+    self.innerSubview2.lyt_left = 2;
+    XCTAssertFalse([self.innerSubview2 lyt_after:self.innerSubview1 fromCenter:FALSE]);
 }
 
 - (void)testAfterRightToLeft {
@@ -112,6 +130,8 @@ static BOOL isLeftToRight = YES;
     XCTAssertTrue([self.innerSubview1 lyt_after:self.innerSubview2]);
     self.innerSubview1.lyt_left = 0.0000001;
     XCTAssertTrue([self.innerSubview1 lyt_after:self.innerSubview2]);
+    self.innerSubview1.lyt_left = 2;
+    XCTAssertTrue([self.innerSubview1 lyt_after:self.innerSubview2 fromCenter:YES]);
 
     // Failure expected
 
@@ -119,6 +139,10 @@ static BOOL isLeftToRight = YES;
     XCTAssertFalse([self.innerSubview1 lyt_after:self.innerSubview2]);
     self.innerSubview1.lyt_left = 0;
     XCTAssertFalse([self.innerSubview2 lyt_after:self.innerSubview1]);
+    self.innerSubview1.lyt_left = 3;
+    XCTAssertFalse([self.innerSubview1 lyt_after:self.innerSubview2 fromCenter:YES]);
+    self.innerSubview1.lyt_left = 2;
+    XCTAssertFalse([self.innerSubview1 lyt_after:self.innerSubview2 fromCenter:NO]);
 }
 
 #pragma mark - Above


### PR DESCRIPTION
This restores an older feature that appears to have been lost when migrating to open-source. I've overloaded lyt_before and lyt_after to support a fromCenter parameter. If set to YES, the code will then test for whether a view is before or after the center of another view, allowing some overlapping. If NO, (equivalent to the original method), the view must strictly be before or after the edge of the other view - no overlapping.