### PR TITLE
Add ImageValues Generator

### DIFF
--- a/LayoutTestBase/Core/Generators/LYTImageValues.h
+++ b/LayoutTestBase/Core/Generators/LYTImageValues.h
@@ -1,0 +1,21 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+#import "LYTDataValues.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(ImageValues)
+@interface LYTImageValues : LYTDataValues
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/LayoutTestBase/Core/Generators/LYTImageValues.m
+++ b/LayoutTestBase/Core/Generators/LYTImageValues.m
@@ -1,0 +1,34 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+#import "LYTImageValues.h"
+
+@implementation LYTImageValues
+
+- (NSArray *)values {
+    return @[
+             [self generateImageWithWidth:1000 height:1000],
+             [self generateImageWithWidth:10 height:10],
+             [self generateImageWithWidth:10 height:1000],
+             [self generateImageWithWidth:1000 height:10],
+             ];
+}
+
+- (UIImage *)generateImageWithWidth:(CGFloat)width height:(CGFloat)height {
+    CGSize size = CGSizeMake(width, height);
+    UIGraphicsBeginImageContextWithOptions(size, YES, 0);
+    [[UIColor redColor] setFill];
+    UIRectFill(CGRectMake(0, 0, size.width, size.height));
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+@end
+


### PR DESCRIPTION
# SUMMARY
ImageValues will generate UIImages with different sizes .

# USAGE
It can be useful when you need to check how different size for an image will affect the layout, 
e.g. if you have the imageView inside a stackView without setting height/width constraints the imageView will resize based on the image size which may cause issues in the layout. 
