### PR TITLE
Add in a max number of combinations flag to fail test cases if they get beyond a complexity threshold

### DIFF
--- a/LayoutTest.xcodeproj/project.pbxproj
+++ b/LayoutTest.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		49E33B02219F3F15009398FA /* LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 49E33B01219F3F14009398FA /* LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m */; };
 		5667F66B1C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 5667F6691C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.h */; };
 		5667F66C1C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 5667F66A1C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.m */; };
 		5667F66F1C6600FA0042C3BB /* LYTLayoutFailingTestSnapshotRecorderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5667F66D1C6600FA0042C3BB /* LYTLayoutFailingTestSnapshotRecorderTests.m */; };
@@ -101,6 +102,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		49E33B01219F3F14009398FA /* LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m; sourceTree = "<group>"; };
 		5667F6691C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LYTLayoutFailingTestSnapshotRecorder.h; sourceTree = "<group>"; };
 		5667F66A1C65FCE50042C3BB /* LYTLayoutFailingTestSnapshotRecorder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LYTLayoutFailingTestSnapshotRecorder.m; sourceTree = "<group>"; };
 		5667F66D1C6600FA0042C3BB /* LYTLayoutFailingTestSnapshotRecorderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LYTLayoutFailingTestSnapshotRecorderTests.m; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 				614FE6AE1C03F05E00BB9EE6 /* LayoutTestCaseOverlapTests.m */,
 				614FE6AF1C03F05E00BB9EE6 /* LayoutTestCaseWithinSuperviewTests.m */,
 				61CACFB51C1A560000369461 /* LayoutTestCaseViewSizesTests.m */,
+				49E33B01219F3F14009398FA /* LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m */,
 				61CACFB71C1A592000369461 /* LayoutTestCaseViewSizesConfigTests.m */,
 				C56317F01C6373FE00A8E8BA /* LayoutTestCaseMultipleDataOverlapTests.m */,
 				C59A16441C6A2C20002AC07C /* LayoutReportSnapshotLocationsTests.m */,
@@ -658,6 +661,7 @@
 				614FE6B91C03F05E00BB9EE6 /* LayoutTestCaseAmbiguousTests.m in Sources */,
 				614FE6B51C03F05E00BB9EE6 /* DataValuesTests.m in Sources */,
 				614FE6B31C03F05E00BB9EE6 /* AutolayoutFailureInterceptorTests.m in Sources */,
+				49E33B02219F3F15009398FA /* LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m in Sources */,
 				C59A16451C6A2C20002AC07C /* LayoutReportSnapshotLocationsTests.m in Sources */,
 				5667F66F1C6600FA0042C3BB /* LYTLayoutFailingTestSnapshotRecorderTests.m in Sources */,
 				614FE6B81C03F05E00BB9EE6 /* LayoutTestCaseAccessibilityControlTests.m in Sources */,

--- a/LayoutTest/TestCase/LYTLayoutTestCase.h
+++ b/LayoutTest/TestCase/LYTLayoutTestCase.h
@@ -115,6 +115,15 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Config
 
 /**
+ If set, when running a LYTLayoutTestCase, it will fail the test if there are more combinations than this value.
+
+ You can also globally set this as a default in LYTConfig.
+
+ Default: nil
+ */
+@property (nonatomic, nullable) NSNumber *maxNumberOfCombinations;
+
+/**
  If on, when running a LYTLayoutTestCase, it will automatically check to make sure subviews don't overlap.
 
  You can also globally set this as a default in LYTConfig.

--- a/LayoutTest/TestCase/LYTLayoutTestCase.m
+++ b/LayoutTest/TestCase/LYTLayoutTestCase.m
@@ -74,8 +74,10 @@ NS_ASSUME_NONNULL_BEGIN
                                                        // We must run this first to give the user a chance to add to viewsAllowingOverlap
                                                        validation(view, data, context);
 
-                                                       if (self.maxNumberOfCombinations != nil && numberOfCombinationsExecuted > self.maxNumberOfCombinations.integerValue) {
-                                                           [self failTest:@"Max number of combinations exceeded" view:view];
+                                                       if (self.maxNumberOfCombinations != nil &&
+                                                           numberOfCombinationsExecuted > self.maxNumberOfCombinations.integerValue) {
+                                                           NSString *errorMessage = [NSString stringWithFormat:@"Max number of layout combinations (%ld) exceeded.", self.maxNumberOfCombinations.integerValue];
+                                                           [self failTest:errorMessage view:view];
                                                        }
                                                        
                                                        // Now, let's run our tests

--- a/LayoutTest/TestCase/LYTLayoutTestCase.m
+++ b/LayoutTest/TestCase/LYTLayoutTestCase.m
@@ -59,6 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
         }];
     }
 
+    __block NSInteger numberOfCombinationsExecuted = 0;
+    
     [LYTLayoutPropertyTester runPropertyTestsWithViewProvider:viewProvider
                                                  limitResults:limitResults
                                                    validation:^(id view, NSDictionary *data, id _Nullable context) {
@@ -67,8 +69,14 @@ NS_ASSUME_NONNULL_BEGIN
                                                        self.viewUnderTest = view;
                                                        self.dataForViewUnderTest = data;
 
+                                                       numberOfCombinationsExecuted++;
+
                                                        // We must run this first to give the user a chance to add to viewsAllowingOverlap
                                                        validation(view, data, context);
+
+                                                       if (self.maxNumberOfCombinations != nil && numberOfCombinationsExecuted > self.maxNumberOfCombinations.integerValue) {
+                                                           [self failTest:@"Max number of combinations exceeded" view:view];
+                                                       }
                                                        
                                                        // Now, let's run our tests
                                                        [self runBasicRecursiveViewTests:view];
@@ -76,6 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                        // Now, let's reset these for the next run
                                                        self.viewsAllowingOverlap = [NSMutableSet set];
                                                        self.viewsAllowingAccessibilityErrors = [NSMutableSet set];
+
                                                    }];
 }
 
@@ -86,6 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Config
 
+    self.maxNumberOfCombinations = [LYTConfig sharedInstance].maxNumberOfCombinations;
     self.viewOverlapTestsEnabled = [LYTConfig sharedInstance].viewOverlapTestsEnabled;
     self.viewWithinSuperviewTestsEnabled = [LYTConfig sharedInstance].viewWithinSuperviewTestsEnabled;
     self.ambiguousAutolayoutTestsEnabled = [LYTConfig sharedInstance].ambiguousAutolayoutTestsEnabled;

--- a/LayoutTestBase/Config/LYTConfig.h
+++ b/LayoutTestBase/Config/LYTConfig.h
@@ -16,6 +16,13 @@ NS_SWIFT_NAME(Config)
 @interface LYTConfig : NSObject
 
 /**
+ If set, when running a LYTLayoutTestCase, it will fail the test if there are more combinations than this value.
+
+ Default: nil
+ */
+@property (nonatomic, nullable) NSNumber *maxNumberOfCombinations;
+
+/**
  An NSArray of LYTViewSizes. If a test does not specify any view sizes with sizesForView in the LYTViewProvider it will instead use these sizes.
  */
 @property (nonatomic, strong, nullable) NSArray *viewSizesToTest;

--- a/LayoutTestBase/Config/LYTConfig.m
+++ b/LayoutTestBase/Config/LYTConfig.m
@@ -30,6 +30,7 @@ NSUInteger const LYTSaveUnlimitedSnapshotsPerMethod = -1;
 }
 
 - (void)resetDefaults {
+    self.maxNumberOfCombinations = nil;
     self.viewSizesToTest = nil;
     self.viewOverlapTestsEnabled = YES;
     self.viewWithinSuperviewTestsEnabled = YES;

--- a/LayoutTestTests/ConfigTests.m
+++ b/LayoutTestTests/ConfigTests.m
@@ -24,6 +24,7 @@
 }
 
 - (void)testConfigEditsLayoutTest {
+    [LYTConfig sharedInstance].maxNumberOfCombinations = @(10);
     [LYTConfig sharedInstance].viewOverlapTestsEnabled = NO;
     [LYTConfig sharedInstance].viewWithinSuperviewTestsEnabled = NO;
     [LYTConfig sharedInstance].ambiguousAutolayoutTestsEnabled = NO;
@@ -34,7 +35,9 @@
     [LYTConfig sharedInstance].viewClassesRequiringAccessibilityLabels = [NSSet set];
 
     LYTLayoutTestCase *testCase = [[LYTLayoutTestCase alloc] init];
+
     [testCase setUp];
+    XCTAssertEqual(testCase.maxNumberOfCombinations, @(10));
     XCTAssertEqual(testCase.viewOverlapTestsEnabled, [LYTConfig sharedInstance].viewOverlapTestsEnabled);
     XCTAssertEqual(testCase.viewWithinSuperviewTestsEnabled, [LYTConfig sharedInstance].viewWithinSuperviewTestsEnabled);
     XCTAssertEqual(testCase.ambiguousAutolayoutTestsEnabled, [LYTConfig sharedInstance].ambiguousAutolayoutTestsEnabled);
@@ -59,6 +62,7 @@
 }
 
 - (void)testResetDefaultsResetsToExpectedValues {
+    [LYTConfig sharedInstance].maxNumberOfCombinations = @(100);
     [LYTConfig sharedInstance].viewOverlapTestsEnabled = NO;
     [LYTConfig sharedInstance].viewWithinSuperviewTestsEnabled = NO;
     [LYTConfig sharedInstance].ambiguousAutolayoutTestsEnabled = NO;
@@ -71,7 +75,8 @@
     [LYTConfig sharedInstance].snapshotsToSavePerMethod = 100;
     
     [[LYTConfig sharedInstance] resetDefaults];
-    
+
+    XCTAssertNil([LYTConfig sharedInstance].maxNumberOfCombinations);
     XCTAssertEqual(YES, [LYTConfig sharedInstance].viewOverlapTestsEnabled);
     XCTAssertEqual(YES, [LYTConfig sharedInstance].viewWithinSuperviewTestsEnabled);
     XCTAssertEqual(YES, [LYTConfig sharedInstance].ambiguousAutolayoutTestsEnabled);

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m
@@ -1,0 +1,107 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+#import "LayoutTest.h"
+#import "LayoutTestBase.h"
+#import "UnitTestViews.h"
+
+
+@interface LayoutTestCaseViewMaxNumberOfCombinationsConfigTests : LYTLayoutTestCase <LYTViewProvider>
+
+@property (nonatomic) NSInteger testFailures;
+
+@end
+
+@implementation LayoutTestCaseViewMaxNumberOfCombinationsConfigTests
+
+- (void)testThatTestDoesNotFailIfMaxNumberOfCombinationsNilBeforeRunningTests {
+    self.maxNumberOfCombinations = nil;
+    [self runLayoutTestsWithViewProvider:[self class] limitResults:LYTTesterLimitResultsNone validation:^(UIView * view, NSDictionary * data, id context) { }];
+
+    XCTAssertEqual(self.testFailures, 0);
+}
+
+- (void)testThatTestDoesNotFailIfMaxNumberOfCombinationsSetToNilInValidationBlock {
+    [self runLayoutTestsWithViewProvider:[self class] limitResults:LYTTesterLimitResultsNone validation:^(UIView * view, NSDictionary * data, id context) {
+        self.maxNumberOfCombinations = nil;
+    }];
+
+    XCTAssertEqual(self.testFailures, 0);
+}
+
+- (void)testThatTestFailsIfMaxNumberOfCombinationsSetToZeroBeforeRunningTests {
+    self.maxNumberOfCombinations = @(0);
+    [self runLayoutTestsWithViewProvider:[self class] limitResults:LYTTesterLimitResultsNone validation:^(UIView * view, NSDictionary * data, id context) { }];
+
+    XCTAssertEqual(self.testFailures, 9);
+}
+
+- (void)testThatTestFailsIfMaxNumberOfCombinationsSetToZeroInValidationBlock {
+    [self runLayoutTestsWithViewProvider:[self class] limitResults:LYTTesterLimitResultsNone validation:^(UIView * view, NSDictionary * data, id context) {
+        self.maxNumberOfCombinations = @(0);
+    }];
+
+    XCTAssertEqual(self.testFailures, 9);
+}
+
+- (void)testThatTestFailsIfNumberOfCombinationsExceedesMaxNumberOfCombinationsSetBeforeRunningTests {
+    self.maxNumberOfCombinations = @(1);
+    [self runLayoutTestsWithViewProvider:[self class] limitResults:LYTTesterLimitResultsNone validation:^(UIView * view, NSDictionary * data, id context) { }];
+
+    XCTAssertEqual(self.testFailures, 8);
+}
+
+- (void)testThatTestFailsIfNumberOfCombinationsExceedesMaxNumberOfCombinationsSetInValidationBlock {
+    [self runLayoutTestsWithViewProvider:[self class] limitResults:LYTTesterLimitResultsNone validation:^(UIView * view, NSDictionary * data, id context) {
+        self.maxNumberOfCombinations = @(3);
+    }];
+
+    XCTAssertEqual(self.testFailures, 6);
+}
+
+- (void)testThatTestSucceedsIfNumberOfCombinationsDoesNotExceedesMaxNumberOfCombinationsSetBeforeRunningTests {
+    self.maxNumberOfCombinations = @(4);
+    [self runLayoutTestsWithViewProvider:[self class] limitResults:LYTTesterLimitResultsNone validation:^(UIView * view, NSDictionary * data, id context) { }];
+
+    XCTAssertEqual(self.testFailures, 5);
+}
+
+- (void)testThatTestSucceedsIfNumberOfCombinationsDoesNotExceedesMaxNumberOfCombinationsSetInValidationBlock {
+    [self runLayoutTestsWithViewProvider:[self class] limitResults:LYTTesterLimitResultsNone validation:^(UIView * view, NSDictionary * data, id context) {
+        self.maxNumberOfCombinations = @(5);
+    }];
+
+    XCTAssertEqual(self.testFailures, 4);
+}
+
+- (void)failTest:(NSString *)errorMessage view:(UIView *)view {
+    self.testFailures++;
+}
+
+#pragma mark - LYTViewProvider
+
++ (NSDictionary *)dataSpecForTest {
+    return @{
+             @"someValues": [[LYTDataValues alloc] initWithValues:@[@(1), @(2), @(3)]]
+             };
+}
+
++ (UIView *)viewForData:(NSDictionary *)data reuseView:(UIView *)view size:(LYTViewSize *)size context:(id *)context {
+    return view ?: [UnitTestViews viewWithNoProblems];
+}
+
++ (NSArray<LYTViewSize *> *)sizesForView {
+    return @[
+             [[LYTViewSize alloc] initWithWidth:@(100) height:@(100)],
+              [[LYTViewSize alloc] initWithWidth:@(200) height:@(200)],
+              [[LYTViewSize alloc] initWithWidth:@(300) height:@(300)],
+             ];
+}
+
+@end

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m
@@ -15,10 +15,17 @@
 @interface LayoutTestCaseViewMaxNumberOfCombinationsConfigTests : LYTLayoutTestCase <LYTViewProvider>
 
 @property (nonatomic) NSInteger testFailures;
+@property (nonatomic, strong) NSString *lastTestFailureMessage;
 
 @end
 
 @implementation LayoutTestCaseViewMaxNumberOfCombinationsConfigTests
+
+- (void)setUp {
+    [super setUp];
+    self.testFailures = 0;
+    self.lastTestFailureMessage = nil;
+}
 
 - (void)testThatTestDoesNotFailIfMaxNumberOfCombinationsNilBeforeRunningTests {
     self.maxNumberOfCombinations = nil;
@@ -80,8 +87,17 @@
     XCTAssertEqual(self.testFailures, 4);
 }
 
+- (void)testThatTestFailureMessageIndicatesMaxNumberOfCombinations {
+    [self runLayoutTestsWithViewProvider:[self class] limitResults:LYTTesterLimitResultsNone validation:^(UIView * view, NSDictionary * data, id context) {
+        self.maxNumberOfCombinations = @(5);
+    }];
+
+    XCTAssertEqualObjects(self.lastTestFailureMessage, @"Max number of layout combinations (5) exceeded.");
+}
+
 - (void)failTest:(NSString *)errorMessage view:(UIView *)view {
     self.testFailures++;
+    self.lastTestFailureMessage = errorMessage;
 }
 
 #pragma mark - LYTViewProvider


### PR DESCRIPTION
With a large project and many folks writing layout tests, we want to have some control over the complexity of tests. One large test with 10s of combinations might be able to be broken down into a few tests, each with just a few combinations.

Let me know what you think and if you have any feedback