### PR TITLE
Remove redundant dependencies, bump version to 5.0.1

### DIFF
--- a/LayoutTest.podspec
+++ b/LayoutTest.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'LayoutTest'
-  spec.version          = '5.0.0'
+  spec.version          = '5.0.1'
   spec.license          = { :type => 'Apache License, Version 2.0' }
   spec.homepage         = 'https://linkedin.github.io/LayoutTest-iOS'
   spec.authors          = 'LinkedIn'
@@ -8,29 +8,25 @@ Pod::Spec.new do |spec|
   spec.source           = { :git => 'https://github.com/linkedin/LayoutTest-iOS.git', :tag => spec.version }
   spec.platform         = :ios, '7.0'
   spec.default_subspecs = 'TestCase'
-  spec.dependency         'LayoutTestBase', '4.0.2'
 
   spec.subspec 'Swift' do |sp|
-    sp.dependency 'LayoutTestBase/Core'
-    sp.dependency 'LayoutTestBase/Autolayout'
-    sp.dependency 'LayoutTestBase/Catalog'
-    sp.dependency 'LayoutTest/TestCase'
-    sp.dependency 'LayoutTestBase/Config'
-    sp.dependency 'LayoutTestBase/UIViewHelpers'
     sp.dependency 'LayoutTest/SwiftSubspec'
   end
 
   spec.subspec 'TestCase' do |sp|
     sp.source_files = 'LayoutTest/TestCase'
-    sp.dependency 'LayoutTestBase/Core'
-    sp.dependency 'LayoutTestBase/Config'
+    sp.dependency 'LayoutTestBase/Autolayout', '5.0.1'
+    sp.dependency 'LayoutTestBase/Catalog', '5.0.1'
+    sp.dependency 'LayoutTestBase/Config', '5.0.1'
+    sp.dependency 'LayoutTestBase/Core', '5.0.1'
+    sp.dependency 'LayoutTestBase/UIViewHelpers', '5.0.1'
     sp.framework  = 'XCTest'
   end
 
   spec.subspec 'SwiftSubspec' do |sp|
     sp.source_files = 'LayoutTest/Swift', 'LayoutTest/LayoutTest.h'
     sp.dependency 'LayoutTest/TestCase'
-    sp.dependency 'LayoutTestBase/Swift'
+    sp.dependency 'LayoutTestBase/Swift', '5.0.1'
   end
 end
 

--- a/LayoutTestBase.podspec
+++ b/LayoutTestBase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'LayoutTestBase'
-  spec.version          = '5.0.0'
+  spec.version          = '5.0.1'
   spec.license          = { :type => 'Apache License, Version 2.0' }
   spec.homepage         = 'https://linkedin.github.io/LayoutTest-iOS'
   spec.authors          = 'LinkedIn'


### PR DESCRIPTION
With the current dependency structure, it is impossible to use both LayoutTestBase and LayoutTest across different targets in the same project.  Cocoapods will add two different projects for LayoutTestBase due to subtle differences in the requested subspecs, which can lead to conflicts when building as they both will output a LayoutTestBase.framework artifact.

This seems to be resolved by removing the default `spec.dependency 'LayoutTestBase'` in favor of explicitly setting subspecs.  TestCase now imports all the default specs from LayoutTestBase to maintain compatibility.

This commit also removes several redundant dependencies from the Swift and SwiftSubspec subspecs.