### PR TITLE
NSObject extensions should always be prefixed

### DIFF
--- a/LayoutTest.podspec
+++ b/LayoutTest.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'LayoutTest'
-  spec.version          = '5.0.4'
+  spec.version          = '6.0.0'
   spec.license          = { :type => 'Apache License, Version 2.0' }
   spec.homepage         = 'https://linkedin.github.io/LayoutTest-iOS'
   spec.authors          = 'LinkedIn'
@@ -16,18 +16,18 @@ Pod::Spec.new do |spec|
 
   spec.subspec 'TestCase' do |sp|
     sp.source_files = 'LayoutTest/TestCase'
-    sp.dependency 'LayoutTestBase/Autolayout', '5.0.4'
-    sp.dependency 'LayoutTestBase/Catalog', '5.0.4'
-    sp.dependency 'LayoutTestBase/Config', '5.0.4'
-    sp.dependency 'LayoutTestBase/Core', '5.0.4'
-    sp.dependency 'LayoutTestBase/UIViewHelpers', '5.0.4'
+    sp.dependency 'LayoutTestBase/Autolayout', '6.0.0'
+    sp.dependency 'LayoutTestBase/Catalog', '6.0.0'
+    sp.dependency 'LayoutTestBase/Config', '6.0.0'
+    sp.dependency 'LayoutTestBase/Core', '6.0.0'
+    sp.dependency 'LayoutTestBase/UIViewHelpers', '6.0.0'
     sp.framework  = 'XCTest'
   end
 
   spec.subspec 'SwiftSubspec' do |sp|
     sp.source_files = 'LayoutTest/Swift', 'LayoutTest/LayoutTest.h'
     sp.dependency 'LayoutTest/TestCase'
-    sp.dependency 'LayoutTestBase/Swift', '5.0.4'
+    sp.dependency 'LayoutTestBase/Swift', '6.0.0'
   end
 end
 

--- a/LayoutTestBase.podspec
+++ b/LayoutTestBase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'LayoutTestBase'
-  spec.version          = '5.0.4'
+  spec.version          = '6.0.0'
   spec.license          = { :type => 'Apache License, Version 2.0' }
   spec.homepage         = 'https://linkedin.github.io/LayoutTest-iOS'
   spec.authors          = 'LinkedIn'

--- a/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.h
+++ b/LayoutTestBase/UIViewHelpers/UIView+LYTFrameComparison.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  \param otherView The view you want to compare to. It does not need to have the same superview, but MUST share some ancestor view.
  \returns True if the view is laid out before another view.
  */
-- (BOOL)lyt_before:(UIView *)otherView NS_SWIFT_NAME(before(_:));
+- (BOOL)lyt_before:(UIView *)otherView;
 
 /**
  Version of lyt_before that takes a fromCenter param. If fromCenter is YES, the comparison starts from the center of the view rather than the
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  \param fromCenter If YES, allow an overlap up to the center of otherView. If NO, behavior is the same as without the param
  \returns True if the view is laid out before another view, allowing for an overlap up to the center if fromCenter is YES.
  */
-- (BOOL)lyt_before:(UIView *)otherView fromCenter:(BOOL)fromCenter NS_SWIFT_NAME(before(_:fromCenter:));
+- (BOOL)lyt_before:(UIView *)otherView fromCenter:(BOOL)fromCenter;
 
 /**
  Returns whether a view is after another view on the horizontal axis. It returns false if they are overlapping in any way.
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  \param otherView The view you want to compare to. It does not need to have the same superview, but MUST share some ancestor view.
  \returns True if the view is laid out after another view.
  */
-- (BOOL)lyt_after:(UIView *)otherView NS_SWIFT_NAME(after(_:));
+- (BOOL)lyt_after:(UIView *)otherView;
 
 /**
  Version of lyt_after that takes a fromCenter param. If fromCenter is YES, the comparison starts from the center of the view rather than the
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  \param fromCenter If YES, allow an overlap up to the center of otherView. If NO, behavior is the same as without the param
  \returns True if the view is laid out before another view, allowing for an overlap up to the center if fromCenter is YES.
  */
-- (BOOL)lyt_after:(UIView *)otherView fromCenter:(BOOL)fromCenter NS_SWIFT_NAME(after(_:fromCenter:));
+- (BOOL)lyt_after:(UIView *)otherView fromCenter:(BOOL)fromCenter;
 
 /**
  Returns whether a view is above another view on the vertical axis. It returns false if they are overlapping in any way.
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
  \param otherView The view you want to compare to. It does not need to have the same superview, but MUST share some ancestor view.
  \returns True if the view is laid out above another view.
  */
-- (BOOL)lyt_above:(UIView *)otherView NS_SWIFT_NAME(above(_:));
+- (BOOL)lyt_above:(UIView *)otherView;
 
 /**
  Returns whether a view is below another view on the vertical axis. It returns false if they are overlapping in any way.
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
  \param otherView The view you want to compare to. It does not need to have the same superview, but MUST share some ancestor view.
  \returns True if the view is laid out below another view.
  */
-- (BOOL)lyt_below:(UIView *)otherView NS_SWIFT_NAME(below(_:));
+- (BOOL)lyt_below:(UIView *)otherView;
 
 /**
  Returns whether the start of a view is aligned with another view on the horizontal axis. It allows views to overlap.
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
  \param otherView The view you want to compare to. It does not need to have the same superview, but MUST share some ancestor view.
  \returns True if the view is start aligned with another view.
  */
-- (BOOL)lyt_leadingAligned:(UIView *)otherView NS_SWIFT_NAME(leadingAligned(_:));
+- (BOOL)lyt_leadingAligned:(UIView *)otherView;
 
 /**
  Returns whether the end of a view is aligned with another view on the horizontal axis. It allows views to overlap.
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
  \param otherView The view you want to compare to. It does not need to have the same superview, but MUST share some ancestor view.
  \returns True if the view is end aligned with another view.
  */
-- (BOOL)lyt_trailingAligned:(UIView *)otherView NS_SWIFT_NAME(trailingAligned(_:));
+- (BOOL)lyt_trailingAligned:(UIView *)otherView;
 
 /**
  Returns whether the top of a view is aligned with another view on the vertical axis. It allows views to overlap.
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
  \param otherView The view you want to compare to. It does not need to have the same superview, but MUST share some ancestor view.
  \returns True if the view is top aligned with another view.
  */
-- (BOOL)lyt_topAligned:(UIView *)otherView NS_SWIFT_NAME(topAligned(_:));
+- (BOOL)lyt_topAligned:(UIView *)otherView;
 
 /**
  Returns whether the bottom of a view is aligned with another view on the vertical axis. It allows views to overlap.
@@ -121,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
  \param otherView The view you want to compare to. It does not need to have the same superview, but MUST share some ancestor view.
  \returns True if the view is bottom aligned with another view.
  */
-- (BOOL)lyt_bottomAligned:(UIView *)otherView NS_SWIFT_NAME(bottomAligned(_:));
+- (BOOL)lyt_bottomAligned:(UIView *)otherView;
 
 @end
 

--- a/LayoutTestBase/UIViewHelpers/UIView+LYTHelpers.h
+++ b/LayoutTestBase/UIViewHelpers/UIView+LYTHelpers.h
@@ -21,38 +21,38 @@ NS_ASSUME_NONNULL_BEGIN
 
  When setting, it will keep the height and width constant and change frame.origin.y
  */
-@property (nonatomic) CGFloat lyt_top NS_SWIFT_NAME(top);
+@property (nonatomic) CGFloat lyt_top;
 
 /**
  Returns .frame.origin.x
 
  When setting, it will keep the height and width constant and change frame.origin.x
  */
-@property (nonatomic) CGFloat lyt_left NS_SWIFT_NAME(left);
+@property (nonatomic) CGFloat lyt_left;
 
 /**
  Returns .frame.origin.x + .frame.size.width
 
  When setting, it will keep the height and width constant and change frame.origin.x
  */
-@property (nonatomic) CGFloat lyt_right NS_SWIFT_NAME(right);
+@property (nonatomic) CGFloat lyt_right;
 
 /**
  Returns .frame.origin.y + .frame.size.height
 
  When setting, it will keep the height and width constant and change frame.origin.y
  */
-@property (nonatomic) CGFloat lyt_bottom NS_SWIFT_NAME(bottom);
+@property (nonatomic) CGFloat lyt_bottom;
 
 /**
  Returns the width of the view
  */
-@property (nonatomic) CGFloat lyt_width NS_SWIFT_NAME(width);
+@property (nonatomic) CGFloat lyt_width;
 
 /**
  Returns the height of the view
  */
-@property (nonatomic) CGFloat lyt_height NS_SWIFT_NAME(height);
+@property (nonatomic) CGFloat lyt_height;
 
 @end
 

--- a/LayoutTestBase/UIViewHelpers/UIView+LYTTestHelpers.h
+++ b/LayoutTestBase/UIViewHelpers/UIView+LYTTestHelpers.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  cell.contentView because it sometimes fails for the contentView in it's
  superview due to some UIKit weirdness.
  */
-- (void)lyt_assertViewWithinSuperViewBounds:(void(^)(NSString *error, UIView *view))errorBlock NS_SWIFT_NAME(assertViewWithinSuperViewBounds(_:));
+- (void)lyt_assertViewWithinSuperViewBounds:(void(^)(NSString *error, UIView *view))errorBlock;
 
 /**
  Useful helper for writing tests. Ensures recursively that all the subviews of the view are within the bounds of their superviews. If this condition breaks,
@@ -35,14 +35,14 @@ NS_ASSUME_NONNULL_BEGIN
  on cell.contentView because it sometimes fails for the contentView in it's
  superview due to some UIKit weirdness.
  */
-- (void)lyt_recursivelyAssertViewWithinSuperViewBounds:(NS_NOESCAPE void(^)(NSString *error, UIView *view))errorBlock NS_SWIFT_NAME(recursivelyAssertViewWithinSuperViewBounds(_:));
+- (void)lyt_recursivelyAssertViewWithinSuperViewBounds:(NS_NOESCAPE void(^)(NSString *error, UIView *view))errorBlock;
 
 /**
  Useful helper for writing tests. Ensures that none of the subviews of this view overlap.
  
  When comparing CGFloats, (x > y) if and only if (x > y + epsilon). This epsilon value is defined in LYTConfig.
  */
-- (void)lyt_assertNoSubviewsOverlap:(NS_NOESCAPE void(^)(NSString *error, UIView *view1, UIView *view2))errorBlock NS_SWIFT_NAME(assertNoSubviewsOverlap(_:));
+- (void)lyt_assertNoSubviewsOverlap:(NS_NOESCAPE void(^)(NSString *error, UIView *view1, UIView *view2))errorBlock;
 
 /**
  Useful helper for writing tests. Ensures that none of the subviews of this view overlap. It calls this recursively on subviews, but does not test all 
@@ -51,19 +51,19 @@ NS_ASSUME_NONNULL_BEGIN
  
  When comparing CGFloats, (x > y) if and only if (x > y + epsilon). This epsilon value is defined in LYTConfig.
  */
-- (void)lyt_recursivelyAssertNoSubviewsOverlap:(NS_NOESCAPE void(^)(NSString *error, UIView *view1, UIView *view2))errorBlock NS_SWIFT_NAME(recursivelyAssertNoSubviewsOverlap(_:));
+- (void)lyt_recursivelyAssertNoSubviewsOverlap:(NS_NOESCAPE void(^)(NSString *error, UIView *view1, UIView *view2))errorBlock;
 
 /**
  This method first returns the current view, then traverses the view hierarchy.
  */
-- (void)lyt_recursivelyTraverseViewHierarchy:(NS_NOESCAPE void(^)(UIView *subview))subviewBlock NS_SWIFT_NAME(recursivelyTraverseViewHierarchy(_:));
+- (void)lyt_recursivelyTraverseViewHierarchy:(NS_NOESCAPE void(^)(UIView *subview))subviewBlock;
 
 /**
  This method first returns the current view, then traverses the view hierarchy.
 
  It also provides a stop parameter. If you set this to true, then the method will stop recursing on this branch only.
  */
-- (void)lyt_recursivelyTraverseViewHierarchyWithStop:(NS_NOESCAPE void(^)(UIView *subview, BOOL *stopBranch))subviewBlock NS_SWIFT_NAME(recursivelyTraverseViewHierarchyWithStop(_:));
+- (void)lyt_recursivelyTraverseViewHierarchyWithStop:(NS_NOESCAPE void(^)(UIView *subview, BOOL *stopBranch))subviewBlock;
 
 @end
 


### PR DESCRIPTION
If two modules add similarly named methods to an extension inheriting from NSObject, there is no way for consuming apps to disambiguate which they mean to call.  To fix this, we should always prefix extensions on any unowned ObjC objects (even in Swift).

For reference:
https://stackoverflow.com/questions/33892897