### PR TITLE
Update runLayoutTests throwable in Swift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ xcuserdata
 _build
 .buildinfo
 
+# macos
+.DS_Store

--- a/LayoutTest.podspec
+++ b/LayoutTest.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'LayoutTest'
-  spec.version          = '6.0.1'
+  spec.version          = '6.0.2'
   spec.license          = { :type => 'Apache License, Version 2.0' }
   spec.homepage         = 'https://linkedin.github.io/LayoutTest-iOS'
   spec.authors          = 'LinkedIn'

--- a/LayoutTest.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/LayoutTest.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/LayoutTest/Swift/LayoutTestCase.swift
+++ b/LayoutTest/Swift/LayoutTestCase.swift
@@ -48,10 +48,14 @@ open class LayoutTestCase: LYTLayoutTestCase {
      Here you should assert on the properties of the view. If you set a context in your viewForData: method, it will be passed back here.
     */
     open func runLayoutTests<TestableView: ViewProvider>(limitResults: LYTTesterLimitResults = LYTTesterLimitResults(),
-                             validation: (TestableView, [AnyHashable: Any], Any?) -> Void) where TestableView: UIView {
+                             validation: (TestableView, [AnyHashable: Any], Any?) throws -> Void) where TestableView: UIView {
         self.runLayoutTests(withViewProvider: TestableView.self, limitResults: limitResults) { (view, data, context) in
             if let view = view as? TestableView {
-                validation(view, data, context)
+                do {
+                    try validation(view, data, context)
+                } catch {
+                    XCTFail(String(describing: error))
+                }
             } else {
                 self.failTest("The view wasn't of the expected type. Change your method signature to declare the view in the validation closure " +
                     "of the correct type. Expected: \(TestableView.self) Actual: \(type(of: (view) as AnyObject))", view: view as? UIView)
@@ -88,10 +92,14 @@ open class LayoutTestCase: LYTLayoutTestCase {
      */
     open func runLayoutTests<TestableView: UIView, ViewProviderType: ViewProvider>(withViewProvider viewProvider: ViewProviderType.Type,
                              limitResults: LYTTesterLimitResults = LYTTesterLimitResults(),
-                             validation: (TestableView, [AnyHashable: Any], Any?) -> Void) {
+                             validation: (TestableView, [AnyHashable: Any], Any?) throws -> Void) {
         self.runLayoutTests(withViewProvider: viewProvider, limitResults: limitResults) { (view: Any, data, context) in
             if let view = view as? TestableView {
-                validation(view, data, context)
+                do {
+                    try validation(view, data, context)
+                } catch {
+                    XCTFail(String(describing: error))
+                }
             } else {
                 self.failTest("The view wasn't of the expected type. Change your method signature to declare the view in the validation closure " +
                     "of the correct type. Expected: \(TestableView.self) Actual: \(type(of: view))", view: view as? UIView)


### PR DESCRIPTION
- Minor improvements for `.gitignore`
- Make `runLayoutTests` throwable in Swift and handle common failures
- Bump the version