### PR TITLE
Swiftify LYTViewProvider

### DIFF
--- a/LayoutTest.podspec
+++ b/LayoutTest.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name             = 'LayoutTest'
-  spec.version          = '6.0.4'
+  spec.version          = '6.1.0'
   spec.license          = { :type => 'Apache License, Version 2.0' }
   spec.homepage         = 'https://linkedin.github.io/LayoutTest-iOS'
   spec.authors          = 'LinkedIn'
   spec.summary          = 'LayoutTest enables you to write unit tests which test the layout of a view in multiple configurations.'
   spec.source           = { :git => 'https://github.com/linkedin/LayoutTest-iOS.git', :tag => spec.version }
-  spec.platform         = :ios, '7.0'
+  spec.platform         = :ios, '12.0'
   spec.default_subspecs = 'TestCase'
   spec.swift_version    = '5.0'
 
@@ -16,18 +16,18 @@ Pod::Spec.new do |spec|
 
   spec.subspec 'TestCase' do |sp|
     sp.source_files = 'LayoutTest/TestCase'
-    sp.dependency 'LayoutTestBase/Autolayout', '6.0.4'
-    sp.dependency 'LayoutTestBase/Catalog', '6.0.4'
-    sp.dependency 'LayoutTestBase/Config', '6.0.4'
-    sp.dependency 'LayoutTestBase/Core', '6.0.4'
-    sp.dependency 'LayoutTestBase/UIViewHelpers', '6.0.4'
+    sp.dependency 'LayoutTestBase/Autolayout', '6.1.0'
+    sp.dependency 'LayoutTestBase/Catalog', '6.1.0'
+    sp.dependency 'LayoutTestBase/Config', '6.1.0'
+    sp.dependency 'LayoutTestBase/Core', '6.1.0'
+    sp.dependency 'LayoutTestBase/UIViewHelpers', '6.1.0'
     sp.framework  = 'XCTest'
   end
 
   spec.subspec 'SwiftSubspec' do |sp|
     sp.source_files = 'LayoutTest/Swift', 'LayoutTest/LayoutTest.h'
     sp.dependency 'LayoutTest/TestCase'
-    sp.dependency 'LayoutTestBase/Swift', '6.0.4'
+    sp.dependency 'LayoutTestBase/Swift', '6.1.0'
   end
 end
 

--- a/LayoutTest.podspec
+++ b/LayoutTest.podspec
@@ -16,18 +16,18 @@ Pod::Spec.new do |spec|
 
   spec.subspec 'TestCase' do |sp|
     sp.source_files = 'LayoutTest/TestCase'
-    sp.dependency 'LayoutTestBase/Autolayout', '6.1.0'
-    sp.dependency 'LayoutTestBase/Catalog', '6.1.0'
-    sp.dependency 'LayoutTestBase/Config', '6.1.0'
-    sp.dependency 'LayoutTestBase/Core', '6.1.0'
-    sp.dependency 'LayoutTestBase/UIViewHelpers', '6.1.0'
+    sp.dependency 'LayoutTestBase/Autolayout', #{spec.version}
+    sp.dependency 'LayoutTestBase/Catalog', #{spec.version}
+    sp.dependency 'LayoutTestBase/Config', #{spec.version}
+    sp.dependency 'LayoutTestBase/Core', #{spec.version}
+    sp.dependency 'LayoutTestBase/UIViewHelpers', #{spec.version}
     sp.framework  = 'XCTest'
   end
 
   spec.subspec 'SwiftSubspec' do |sp|
     sp.source_files = 'LayoutTest/Swift', 'LayoutTest/LayoutTest.h'
     sp.dependency 'LayoutTest/TestCase'
-    sp.dependency 'LayoutTestBase/Swift', '6.1.0'
+    sp.dependency 'LayoutTestBase/Swift', #{spec.version}
   end
 end
 

--- a/LayoutTest.podspec
+++ b/LayoutTest.podspec
@@ -16,18 +16,18 @@ Pod::Spec.new do |spec|
 
   spec.subspec 'TestCase' do |sp|
     sp.source_files = 'LayoutTest/TestCase'
-    sp.dependency 'LayoutTestBase/Autolayout', #{spec.version}
-    sp.dependency 'LayoutTestBase/Catalog', #{spec.version}
-    sp.dependency 'LayoutTestBase/Config', #{spec.version}
-    sp.dependency 'LayoutTestBase/Core', #{spec.version}
-    sp.dependency 'LayoutTestBase/UIViewHelpers', #{spec.version}
+    sp.dependency 'LayoutTestBase/Autolayout'
+    sp.dependency 'LayoutTestBase/Catalog'
+    sp.dependency 'LayoutTestBase/Config'
+    sp.dependency 'LayoutTestBase/Core'
+    sp.dependency 'LayoutTestBase/UIViewHelpers'
     sp.framework  = 'XCTest'
   end
 
   spec.subspec 'SwiftSubspec' do |sp|
     sp.source_files = 'LayoutTest/Swift', 'LayoutTest/LayoutTest.h'
     sp.dependency 'LayoutTest/TestCase'
-    sp.dependency 'LayoutTestBase/Swift', #{spec.version}
+    sp.dependency 'LayoutTestBase/Swift'
   end
 end
 

--- a/LayoutTest.xcodeproj/project.pbxproj
+++ b/LayoutTest.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -575,8 +575,9 @@
 		615296F4187CAEEB00BAF959 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1500;
 				ORGANIZATIONNAME = LinkedIn;
 				TargetAttributes = {
 					614FE6381C03EE3C00BB9EE6 = {
@@ -727,7 +728,7 @@
 			buildSettings = {
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -741,8 +742,14 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = LayoutTest/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = LinkedIn.LayoutTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -760,7 +767,7 @@
 			buildSettings = {
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -769,14 +776,21 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
+				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks/**";
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = LayoutTest/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = LinkedIn.LayoutTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -801,8 +815,12 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = LayoutTestTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = LinkedIn.LayoutTestTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -824,8 +842,12 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = LayoutTestTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = LinkedIn.LayoutTestTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -869,6 +891,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -888,7 +911,7 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
@@ -933,6 +956,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -945,11 +969,11 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "LayoutTest/LayoutTest-Bridging-Header.h";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -960,7 +984,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -973,8 +997,14 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = LayoutTestBase/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = LinkedIn.LayoutTestBase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -993,7 +1023,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -1007,8 +1037,14 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = LayoutTestBase/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = LinkedIn.LayoutTestBase;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/LayoutTest.xcodeproj/xcshareddata/xcschemes/LayoutTest.xcscheme
+++ b/LayoutTest.xcodeproj/xcshareddata/xcschemes/LayoutTest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/LayoutTest.xcodeproj/xcshareddata/xcschemes/LayoutTestBase.xcscheme
+++ b/LayoutTest.xcodeproj/xcshareddata/xcschemes/LayoutTestBase.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/LayoutTest/TestCase/LYTLayoutFailingTestSnapshotRecorder.m
+++ b/LayoutTest/TestCase/LYTLayoutFailingTestSnapshotRecorder.m
@@ -105,7 +105,7 @@ void SimpleLog(NSString *format, ...) {
     }
 }
 
-- (void)testCase:(XCTestCase *)testCase didFailWithDescription:(__unused NSString *)description inFile:(nullable __unused NSString *)filePath atLine:(__unused NSUInteger)lineNumber {
+- (void)testCase:(XCTestCase *)testCase didRecordIssue:(XCTIssue *)issue {
     if ([testCase isKindOfClass:[LYTLayoutTestCase class]]) {
         NSString *pathForSnapshots = [self commonRootPathForInvocationClass:[testCase class]];
         pathForSnapshots = [pathForSnapshots stringByAppendingString:@"/index.html"];

--- a/LayoutTest/TestCase/LYTLayoutFailingTestSnapshotRecorder.m
+++ b/LayoutTest/TestCase/LYTLayoutFailingTestSnapshotRecorder.m
@@ -105,7 +105,7 @@ void SimpleLog(NSString *format, ...) {
     }
 }
 
-- (void)testCase:(XCTestCase *)testCase didRecordIssue:(XCTIssue *)issue {
+- (void)testCase:(XCTestCase *)testCase didRecordIssue:(__unused XCTIssue *)issue {
     if ([testCase isKindOfClass:[LYTLayoutTestCase class]]) {
         NSString *pathForSnapshots = [self commonRootPathForInvocationClass:[testCase class]];
         pathForSnapshots = [pathForSnapshots stringByAppendingString:@"/index.html"];

--- a/LayoutTest/TestCase/LYTLayoutTestCase.m
+++ b/LayoutTest/TestCase/LYTLayoutTestCase.m
@@ -232,10 +232,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Failing Test Snapshots
 
-- (void)recordFailureWithDescription:(NSString *)description inFile:(NSString *)filePath atLine:(NSUInteger)lineNumber expected:(BOOL)expected {
-    [super recordFailureWithDescription:description inFile:filePath atLine:lineNumber expected:expected];
+- (void)recordIssue:(XCTIssue *)issue {
+    [super recordIssue:issue];
     if (self.failingTestSnapshotsEnabled) {
-        [[LYTLayoutFailingTestSnapshotRecorder sharedInstance] saveImageOfView:self.viewUnderTest withData:self.dataForViewUnderTest fromInvocation:self.invocation failureDescription:description];
+        [[LYTLayoutFailingTestSnapshotRecorder sharedInstance] saveImageOfView:self.viewUnderTest
+                                                                      withData:self.dataForViewUnderTest
+                                                                fromInvocation:self.invocation
+                                                            failureDescription:issue.compactDescription];
     }
 }
 

--- a/LayoutTestBase.podspec
+++ b/LayoutTestBase.podspec
@@ -18,7 +18,6 @@ Pod::Spec.new do |spec|
     sp.dependency 'LayoutTestBase/Catalog'
     sp.dependency 'LayoutTestBase/Config'
     sp.dependency 'LayoutTestBase/UIViewHelpers'
-    sp.platform = :ios, '12.0'
   end
 
   spec.subspec 'Core' do |sp|

--- a/LayoutTestBase.podspec
+++ b/LayoutTestBase.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name             = 'LayoutTestBase'
-  spec.version          = '6.0.4'
+  spec.version          = '6.1.0'
   spec.license          = { :type => 'Apache License, Version 2.0' }
   spec.homepage         = 'https://linkedin.github.io/LayoutTest-iOS'
   spec.authors          = 'LinkedIn'
   spec.summary          = 'Base library for LayoutTest without XCTest dependency. LayoutTest enables you to write unit tests which test the layout of views.'
   spec.source           = { :git => 'https://github.com/linkedin/LayoutTest-iOS.git', :tag => spec.version }
-  spec.platform         = :ios, '7.0'
+  spec.platform         = :ios, '12.0'
   spec.frameworks       = 'Foundation', 'UIKit'
   spec.default_subspecs = 'Core', 'Autolayout', 'Catalog', 'Config', 'UIViewHelpers'
   spec.swift_version    = '5.0'
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
     sp.dependency 'LayoutTestBase/Catalog'
     sp.dependency 'LayoutTestBase/Config'
     sp.dependency 'LayoutTestBase/UIViewHelpers'
-    sp.platform = :ios, '8.0'
+    sp.platform = :ios, '12.0'
   end
 
   spec.subspec 'Core' do |sp|

--- a/LayoutTestBase/Catalog/LYTCatalogCollectionViewController.m
+++ b/LayoutTestBase/Catalog/LYTCatalogCollectionViewController.m
@@ -76,8 +76,14 @@
     UICollectionViewCell *cell = [self.collectionView dequeueReusableCellWithReuseIdentifier:[self.ViewProviderClass reuseIdentifier] forIndexPath:indexPath];
 
     id context = nil;
-    cell = (UICollectionViewCell *)[self.ViewProviderClass viewForData:self.dataArray[(NSUInteger)indexPath.row] reuseView:cell size:nil context:&context];
-    
+    NSError *error;
+    cell = (UICollectionViewCell *)[self.ViewProviderClass viewForData:self.dataArray[(NSUInteger)indexPath.row] 
+                                                             reuseView:cell
+                                                                  size:nil
+                                                               context:&context
+                                                                 error:&error];
+    NSAssert(error == nil, error.description);
+
     return cell;
 }
 

--- a/LayoutTestBase/Catalog/LYTCatalogTableViewController.m
+++ b/LayoutTestBase/Catalog/LYTCatalogTableViewController.m
@@ -68,7 +68,13 @@
     if ([(id)self.ViewProviderClass respondsToSelector:@selector(tableViewCellForCatalogFromData:reuseCell:)]) {
         cell = [self.ViewProviderClass tableViewCellForCatalogFromData:self.dataArray[(NSUInteger)indexPath.row] reuseCell:cell];
     } else {
-        cell = (UITableViewCell *)[self.ViewProviderClass viewForData:self.dataArray[(NSUInteger)indexPath.row] reuseView:cell size:nil context:nil];
+        NSError *error;
+        cell = (UITableViewCell *)[self.ViewProviderClass viewForData:self.dataArray[(NSUInteger)indexPath.row] 
+                                                            reuseView:cell
+                                                                 size:nil
+                                                              context:nil
+                                                                error:&error];
+        NSAssert(error == nil, error.description);
         NSAssert([cell isKindOfClass:[UITableViewCell class]], @"If your view is not a UITableViewCell, you must implement cellForCatalogFromData:reuseCell:");
     }
 

--- a/LayoutTestBase/Core/LYTViewProvider.h
+++ b/LayoutTestBase/Core/LYTViewProvider.h
@@ -33,7 +33,7 @@ NS_SWIFT_NAME(ViewProvider)
  \returns Template for the data to test on.
  */
 @required
-+ (NSDictionary *)dataSpecForTest;
++ (nullable NSDictionary *)dataSpecForTestWithError:(NSError * _Nullable *)error;
 
 /**
  This method should return a view to run your tests on. You should always use the reuse view if you can, and if not, should recreate a view with the same size as the reuseView. You should then inflate the view with your data and return it.
@@ -46,7 +46,11 @@ NS_SWIFT_NAME(ViewProvider)
  \returns View inflated with data
  */
 @required
-+ (UIView *)viewForData:(NSDictionary *)data reuseView:(nullable UIView *)reuseView size:(nullable LYTViewSize *)size context:(id _Nullable * _Nullable)context;
++ (nullable UIView *)viewForData:(NSDictionary *)data
+                       reuseView:(nullable UIView *)reuseView
+                            size:(nullable LYTViewSize *)size
+                         context:(id _Nullable * _Nullable)context
+                           error:(NSError * _Nullable *)error;
 
 /**
  Returns an array of NSValue objects which wrap a CGSize struct. These are all the sizes that we should test on. The way this works is a little tricky though. It will return a reuse view of this specific size to viewForData:reuseView:. So if that method resizes the view or recreates the view, then this data will be lost.
@@ -69,7 +73,12 @@ NS_SWIFT_NAME(ViewProvider)
  \param context If a context was set in viewForData:reuseView:size:context:, it will be passed back to you here.
  */
 @optional
-+ (void)adjustViewSize:(UIView *)view data:(NSDictionary *)data size:(nullable LYTViewSize *)size context:(nullable id)context;
++ (void)adjustViewSize:(UIView *)view 
+                  data:(NSDictionary *)data
+                  size:(nullable LYTViewSize *)size
+               context:(nullable id)context
+                 error:(NSError * _Nullable *)error
+__attribute__((swift_error(nonnull_error)));
 
 @end
 

--- a/LayoutTestBase/Swift/LYTViewSize+Swift.swift
+++ b/LayoutTestBase/Swift/LYTViewSize+Swift.swift
@@ -13,7 +13,7 @@ extension ViewSize {
     /**
      The width for the view. If nil, do not edit the width.
      */
-    open var width: CGFloat? {
+    public var width: CGFloat? {
         get {
             return __width.flatMap { CGFloat( $0.floatValue ) }
         }
@@ -22,7 +22,7 @@ extension ViewSize {
     /**
      The height for the view. If nil, do not edit the height.
      */
-    open var height: CGFloat? {
+    public var height: CGFloat? {
         get {
             return __height.flatMap {  CGFloat( $0.floatValue ) }
         }

--- a/LayoutTestTests/Helpers/UnitTestViews.m
+++ b/LayoutTestTests/Helpers/UnitTestViews.m
@@ -37,9 +37,9 @@
     [superview addSubview:view2];
 
     NSDictionary *viewsDictionary = @{
-                                      @"view1": view1,
-                                      @"view2": view2
-                                      };
+        @"view1": view1,
+        @"view2": view2
+    };
     [superview addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"[view1]-0-[view2]" options:0 metrics:nil views:viewsDictionary]];
     [superview addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"[view1]-10-[view2]" options:0 metrics:nil views:viewsDictionary]];
 

--- a/LayoutTestTests/IteratorTests.m
+++ b/LayoutTestTests/IteratorTests.m
@@ -40,146 +40,146 @@ static NSDictionary *testData = nil;
 - (void)testNoGenerators
 {
     testData = @{
-                 @"array": @[@"a1", @"a2"],
-                 @"dict": @{@"dk1": @"dv1"},
-                 @"key": @"value"
-                 };
+        @"array": @[@"a1", @"a2"],
+        @"dict": @{@"dk1": @"dv1"},
+        @"key": @"value"
+    };
     __block NSUInteger numberTimesCalled = 0;
     [LYTLayoutPropertyTester runPropertyTestsWithViewProvider:[self class]
-                                                       validation:^(__unused UIView *view, NSDictionary *data, __unused id context) {
-                                                           numberTimesCalled++;
-                                                           XCTAssertEqualObjects(testData[@"key"], data[@"key"], @"Object should match test data");
-                                                           XCTAssertEqualObjects(testData[@"array"][0], data[@"array"][0], @"Object should match test data");
-                                                           XCTAssertEqualObjects(testData[@"array"][1], data[@"array"][1], @"Object should match test data");
-                                                           XCTAssertEqualObjects(testData[@"dict"][@"dk1"], data[@"dict"][@"dk1"], @"Object should match test data");
-                                                       }];
+                                                   validation:^(__unused UIView *view, NSDictionary *data, __unused id context) {
+        numberTimesCalled++;
+        XCTAssertEqualObjects(testData[@"key"], data[@"key"], @"Object should match test data");
+        XCTAssertEqualObjects(testData[@"array"][0], data[@"array"][0], @"Object should match test data");
+        XCTAssertEqualObjects(testData[@"array"][1], data[@"array"][1], @"Object should match test data");
+        XCTAssertEqualObjects(testData[@"dict"][@"dk1"], data[@"dict"][@"dk1"], @"Object should match test data");
+    }];
     XCTAssertEqual(numberTimesCalled, 1, @"Should have been called exactly once");
 
     // Limited
     testData = @{
-                 @"array": @[@"a1", @"a2"],
-                 @"dict": @{@"dk1": @"dv1"},
-                 @"key": @"value"
-                 };
+        @"array": @[@"a1", @"a2"],
+        @"dict": @{@"dk1": @"dv1"},
+        @"key": @"value"
+    };
     numberTimesCalled = 0;
     [LYTLayoutPropertyTester runPropertyTestsWithViewProvider:[self class]
-                                                     limitResults:LYTTesterLimitResultsLimitDataCombinations
-                                                       validation:^(__unused UIView *view, NSDictionary *data, __unused id context) {
-                                                           numberTimesCalled++;
-                                                           XCTAssertEqualObjects(testData[@"key"], data[@"key"], @"Object should match test data");
-                                                           XCTAssertEqualObjects(testData[@"array"][0], data[@"array"][0], @"Object should match test data");
-                                                           XCTAssertEqualObjects(testData[@"array"][1], data[@"array"][1], @"Object should match test data");
-                                                           XCTAssertEqualObjects(testData[@"dict"][@"dk1"], data[@"dict"][@"dk1"], @"Object should match test data");
-                                                       }];
+                                                 limitResults:LYTTesterLimitResultsLimitDataCombinations
+                                                   validation:^(__unused UIView *view, NSDictionary *data, __unused id context) {
+        numberTimesCalled++;
+        XCTAssertEqualObjects(testData[@"key"], data[@"key"], @"Object should match test data");
+        XCTAssertEqualObjects(testData[@"array"][0], data[@"array"][0], @"Object should match test data");
+        XCTAssertEqualObjects(testData[@"array"][1], data[@"array"][1], @"Object should match test data");
+        XCTAssertEqualObjects(testData[@"dict"][@"dk1"], data[@"dict"][@"dk1"], @"Object should match test data");
+    }];
     XCTAssertEqual(numberTimesCalled, 1, @"Should have been called exactly once");
 }
 
 - (void)testOneGeneratorSimple {
     testData = @{
-                 @"gen": [[SampleGenerator alloc] init]
-                 };
+        @"gen": [[SampleGenerator alloc] init]
+    };
     __block NSUInteger numberTimesCalled = 0;
     [LYTLayoutPropertyTester runPropertyTestsWithViewProvider:[self class]
-                                                       validation:^(__unused UIView *view, NSDictionary *data, __unused id context) {
-                                                           XCTAssertEqualObjects(data[@"gen"], @(numberTimesCalled), @"Generator should iterate through all values in order");
-                                                           numberTimesCalled++;
-                                                       }];
+                                                   validation:^(__unused UIView *view, NSDictionary *data, __unused id context) {
+        XCTAssertEqualObjects(data[@"gen"], @(numberTimesCalled), @"Generator should iterate through all values in order");
+        numberTimesCalled++;
+    }];
     XCTAssertEqual(numberTimesCalled, 4, @"Should have been called 4 times");
 
     // Limited
 
     testData = @{
-                 @"gen": [[SampleGenerator alloc] init]
-                 };
+        @"gen": [[SampleGenerator alloc] init]
+    };
     numberTimesCalled = 0;
     [LYTLayoutPropertyTester runPropertyTestsWithViewProvider:[self class]
-                                                     limitResults:LYTTesterLimitResultsLimitDataCombinations
-                                                       validation:^(__unused UIView *view, NSDictionary *data, __unused id context) {
-                                                           XCTAssertEqualObjects(data[@"gen"], @(numberTimesCalled), @"Generator should iterate through all values in order");
-                                                           numberTimesCalled++;
-                                                       }];
+                                                 limitResults:LYTTesterLimitResultsLimitDataCombinations
+                                                   validation:^(__unused UIView *view, NSDictionary *data, __unused id context) {
+        XCTAssertEqualObjects(data[@"gen"], @(numberTimesCalled), @"Generator should iterate through all values in order");
+        numberTimesCalled++;
+    }];
     XCTAssertEqual(numberTimesCalled, 4, @"Should have been called 4 times");
 }
 
 - (void)testTwoGeneratorsSimple {
     testData = @{
-                 @"gen1": [[SampleGenerator alloc] init],
-                 @"gen2": [[SampleGenerator alloc] init]
-                 };
+        @"gen1": [[SampleGenerator alloc] init],
+        @"gen2": [[SampleGenerator alloc] init]
+    };
 
     __block NSUInteger numberTimesCalled = 0;
     [LYTLayoutPropertyTester runPropertyTestsWithViewProvider:[self class]
-                                                       validation:^(__unused UIView *view, NSDictionary *data, id context) {
-                                                           NSArray *dataValues = @[
-                                                                                   (SampleGenerator *)data[@"gen1"],
-                                                                                   (SampleGenerator *)data[@"gen2"]
-                                                                                   ];
-                                                           [self validateGenerators:dataValues context:context];
-                                                           numberTimesCalled++;
-                                                       }];
+                                                   validation:^(__unused UIView *view, NSDictionary *data, id context) {
+        NSArray *dataValues = @[
+            (SampleGenerator *)data[@"gen1"],
+            (SampleGenerator *)data[@"gen2"]
+        ];
+        [self validateGenerators:dataValues context:context];
+        numberTimesCalled++;
+    }];
     XCTAssertEqual(numberTimesCalled, 16, @"Should have been called 16 times");
 
     // Limited
     testData = @{
-                 @"gen1": [[SampleGenerator alloc] init],
-                 @"gen2": [[SampleGenerator alloc] init]
-                 };
+        @"gen1": [[SampleGenerator alloc] init],
+        @"gen2": [[SampleGenerator alloc] init]
+    };
 
     numberTimesCalled = 0;
     [LYTLayoutPropertyTester runPropertyTestsWithViewProvider:[self class]
-                                                     limitResults:LYTTesterLimitResultsLimitDataCombinations
-                                                       validation:^(__unused UIView *view, NSDictionary *data, id context) {
-                                                           NSArray *dataValues = @[
-                                                                                   (SampleGenerator *)data[@"gen1"],
-                                                                                   (SampleGenerator *)data[@"gen2"]
-                                                                                   ];
-                                                           [self validateGenerators:dataValues context:context];
-                                                           numberTimesCalled++;
-                                                       }];
+                                                 limitResults:LYTTesterLimitResultsLimitDataCombinations
+                                                   validation:^(__unused UIView *view, NSDictionary *data, id context) {
+        NSArray *dataValues = @[
+            (SampleGenerator *)data[@"gen1"],
+            (SampleGenerator *)data[@"gen2"]
+        ];
+        [self validateGenerators:dataValues context:context];
+        numberTimesCalled++;
+    }];
     XCTAssertEqual(numberTimesCalled, 7, @"Should have been called 7 times (4 times each mins 1 for the duplicate 0-0)");
 }
 
 - (void)testNestedThreeIterators {
     testData = @{
-                 @"gen1": [[SampleGenerator alloc] init],
-                 @"array": @[@"test", [[SampleGenerator alloc] init]],
-                 @"dict": @{@"test": [[SampleGenerator alloc] init]}
-                 };
+        @"gen1": [[SampleGenerator alloc] init],
+        @"array": @[@"test", [[SampleGenerator alloc] init]],
+        @"dict": @{@"test": [[SampleGenerator alloc] init]}
+    };
 
     __block NSUInteger numberTimesCalled = 0;
     [LYTLayoutPropertyTester runPropertyTestsWithViewProvider:[self class]
-                                                       validation:^(__unused UIView *view, NSDictionary *data, id context) {
+                                                   validation:^(__unused UIView *view, NSDictionary *data, id context) {
 
-                                                           NSArray *dataValues = @[
-                                                                                   (SampleGenerator *)data[@"gen1"],
-                                                                                   (SampleGenerator *)data[@"array"][1],
-                                                                                   (SampleGenerator *)data[@"dict"][@"test"]
-                                                                                   ];
-                                                           [self validateGenerators:dataValues context:context];
-                                                           numberTimesCalled++;
-                                                       }];
+        NSArray *dataValues = @[
+            (SampleGenerator *)data[@"gen1"],
+            (SampleGenerator *)data[@"array"][1],
+            (SampleGenerator *)data[@"dict"][@"test"]
+        ];
+        [self validateGenerators:dataValues context:context];
+        numberTimesCalled++;
+    }];
     XCTAssertEqual(numberTimesCalled, 64, @"Should have been called 64 times");
 
     // Limited
     testData = @{
-                 @"gen1": [[SampleGenerator alloc] init],
-                 @"array": @[@"test", [[SampleGenerator alloc] init]],
-                 @"dict": @{@"test": [[SampleGenerator alloc] init]}
-                 };
+        @"gen1": [[SampleGenerator alloc] init],
+        @"array": @[@"test", [[SampleGenerator alloc] init]],
+        @"dict": @{@"test": [[SampleGenerator alloc] init]}
+    };
 
     numberTimesCalled = 0;
     [LYTLayoutPropertyTester runPropertyTestsWithViewProvider:[self class]
-                                                     limitResults:LYTTesterLimitResultsLimitDataCombinations
-                                                       validation:^(__unused UIView *view, NSDictionary *data, id context) {
+                                                 limitResults:LYTTesterLimitResultsLimitDataCombinations
+                                                   validation:^(__unused UIView *view, NSDictionary *data, id context) {
 
-                                                           NSArray *dataValues = @[
-                                                                                   (SampleGenerator *)data[@"gen1"],
-                                                                                   (SampleGenerator *)data[@"array"][1],
-                                                                                   (SampleGenerator *)data[@"dict"][@"test"]
-                                                                                   ];
-                                                           [self validateGenerators:dataValues context:context];
-                                                           numberTimesCalled++;
-                                                       }];
+        NSArray *dataValues = @[
+            (SampleGenerator *)data[@"gen1"],
+            (SampleGenerator *)data[@"array"][1],
+            (SampleGenerator *)data[@"dict"][@"test"]
+        ];
+        [self validateGenerators:dataValues context:context];
+        numberTimesCalled++;
+    }];
     XCTAssertEqual(numberTimesCalled, 10, @"Should have been called 10 times (4 times each minus 2 for the 0-0-0 duplicates)");
 }
 

--- a/LayoutTestTests/IteratorTests.m
+++ b/LayoutTestTests/IteratorTests.m
@@ -202,11 +202,11 @@ static NSDictionary *testData = nil;
     return testData;
 }
 
-+ (UIView *)viewForData:(__unused NSDictionary *)data
-              reuseView:(__unused UIView *)view
-                   size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context
-                  error:(__unused NSError * _Nullable __autoreleasing *)error {
++ (nullable UIView *)viewForData:(__unused NSDictionary *)data
+                       reuseView:(__unused UIView *)view
+                            size:(__unused LYTViewSize *)size
+                         context:(__unused id __autoreleasing *)context
+                           error:(__unused NSError * _Nullable __autoreleasing *)error {
     return nil;
 }
 

--- a/LayoutTestTests/IteratorTests.m
+++ b/LayoutTestTests/IteratorTests.m
@@ -198,14 +198,15 @@ static NSDictionary *testData = nil;
 
 // View Provider Protocol
 
-+ (NSDictionary *)dataSpecForTest {
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     return testData;
 }
 
 + (UIView *)viewForData:(__unused NSDictionary *)data
               reuseView:(__unused UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing *)error {
     return nil;
 }
 

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutReportSnapshotLocationsTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutReportSnapshotLocationsTests.m
@@ -12,7 +12,6 @@
 
 @interface LYTLayoutFailingTestSnapshotRecorder ()
 @property (nonatomic) NSMutableSet *failingTestsSnapshotFolders;
-- (void)testCase:(XCTestCase *)testCase didFailWithDescription:(NSString *)description inFile:(nullable NSString *)filePath atLine:(NSUInteger)lineNumber;
 @end
 
 @interface LayoutReportSnapshotLocationsTests : LYTLayoutTestCase
@@ -21,7 +20,8 @@
 @implementation LayoutReportSnapshotLocationsTests
 
 - (void)testAllLocationsOfReportsAreLoggedToConsoleAtTheEnd {
-    [[LYTLayoutFailingTestSnapshotRecorder sharedInstance] testCase:self didFailWithDescription:@"" inFile:@"File1" atLine:0];
+    XCTIssue *issue = [[XCTIssue alloc] initWithType:XCTIssueTypeAssertionFailure compactDescription:@""];
+    [[LYTLayoutFailingTestSnapshotRecorder sharedInstance] testCase:self didRecordIssue:issue];
     NSString *expectedPathContaining = @"LayoutTestImages/LayoutReportSnapshotLocationsTests/index.html";
     NSString *actualPath = [LYTLayoutFailingTestSnapshotRecorder sharedInstance].failingTestsSnapshotFolders.anyObject;
     XCTAssertTrue([actualPath containsString:expectedPathContaining]);

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseAccessibilityControlTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseAccessibilityControlTests.m
@@ -84,11 +84,11 @@
 + (NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 2 views to test. One with a button with accessibility, the other a button without accessibility.
     return @{
-             @"view": [[LYTDataValues alloc] initWithValues:@[
-                                                                  [UnitTestViews viewWithButtonAndAccessibility],
-                                                                  [UnitTestViews viewWithButtonAndNoAccessibility]
-                                                                  ]]
-             };
+        @"view": [[LYTDataValues alloc] initWithValues:@[
+            [UnitTestViews viewWithButtonAndAccessibility],
+            [UnitTestViews viewWithButtonAndNoAccessibility]
+        ]]
+    };
 }
 
 + (UIView *)viewForData:(NSDictionary *)data

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseAccessibilityControlTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseAccessibilityControlTests.m
@@ -81,7 +81,7 @@
 
 #pragma mark - LYTViewProvider
 
-+ (NSDictionary *)dataSpecForTest {
++ (NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 2 views to test. One with a button with accessibility, the other a button without accessibility.
     return @{
              @"view": [[LYTDataValues alloc] initWithValues:@[
@@ -94,7 +94,8 @@
 + (UIView *)viewForData:(NSDictionary *)data
               reuseView:(__unused UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing *)error {
     return (UIView *)data[@"view"];
 }
 

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseAmbiguousTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseAmbiguousTests.m
@@ -52,7 +52,7 @@
 
 #pragma mark - LYTViewProvider
 
-+ (NSDictionary *)dataSpecForTest {
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 3 views to test. One correct view, on view with overlapping subviews and one view with a switch subview.
     return @{
              @"view": [[LYTDataValues alloc] initWithValues:@[
@@ -65,7 +65,8 @@
 + (UIView *)viewForData:(NSDictionary *)data
               reuseView:(__unused UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error {
     return (UIView *)data[@"view"];
 }
 

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseAmbiguousTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseAmbiguousTests.m
@@ -55,11 +55,11 @@
 + (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 3 views to test. One correct view, on view with overlapping subviews and one view with a switch subview.
     return @{
-             @"view": [[LYTDataValues alloc] initWithValues:@[
-                                                                  [UnitTestViews viewWithNoProblems],
-                                                                  [UnitTestViews viewWithAmbiguousLayout]
-                                                                  ]]
-             };
+        @"view": [[LYTDataValues alloc] initWithValues:@[
+            [UnitTestViews viewWithNoProblems],
+            [UnitTestViews viewWithAmbiguousLayout]
+        ]]
+    };
 }
 
 + (UIView *)viewForData:(NSDictionary *)data

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseAutolayoutFailureTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseAutolayoutFailureTests.m
@@ -52,7 +52,7 @@
 
 #pragma mark - LYTViewProvider
 
-+ (NSDictionary *)dataSpecForTest {
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 3 views to test. One correct view, on view with overlapping subviews and one view with a switch subview.
     return @{
              @"view": [[LYTDataValues alloc] initWithValues:@[
@@ -65,7 +65,8 @@
 + (UIView *)viewForData:(NSDictionary *)data
               reuseView:(__unused UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error {
     return (UIView *)data[@"view"];
 }
 

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseAutolayoutFailureTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseAutolayoutFailureTests.m
@@ -55,11 +55,11 @@
 + (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 3 views to test. One correct view, on view with overlapping subviews and one view with a switch subview.
     return @{
-             @"view": [[LYTDataValues alloc] initWithValues:@[
-                                                                  [UnitTestViews viewWithNoProblems],
-                                                                  [UnitTestViews viewWithIncorrectAutolayout]
-                                                                  ]]
-             };
+        @"view": [[LYTDataValues alloc] initWithValues:@[
+            [UnitTestViews viewWithNoProblems],
+            [UnitTestViews viewWithIncorrectAutolayout]
+        ]]
+    };
 }
 
 + (UIView *)viewForData:(NSDictionary *)data

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseMissingLabelTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseMissingLabelTests.m
@@ -69,11 +69,11 @@
 + (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 3 views to test. One correct view, on view with overlapping subviews and one view with a switch subview.
     return @{
-             @"view": [[LYTDataValues alloc] initWithValues:@[
-                                                                  [UnitTestViews viewWithNoProblems],
-                                                                  [UnitTestViews viewWithAccessibilityIDButNoLabel]
-                                                                  ]]
-             };
+        @"view": [[LYTDataValues alloc] initWithValues:@[
+            [UnitTestViews viewWithNoProblems],
+            [UnitTestViews viewWithAccessibilityIDButNoLabel]
+        ]]
+    };
 }
 
 + (UIView *)viewForData:(NSDictionary *)data

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseMissingLabelTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseMissingLabelTests.m
@@ -66,7 +66,7 @@
 
 #pragma mark - LYTViewProvider
 
-+ (NSDictionary *)dataSpecForTest {
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 3 views to test. One correct view, on view with overlapping subviews and one view with a switch subview.
     return @{
              @"view": [[LYTDataValues alloc] initWithValues:@[
@@ -79,7 +79,8 @@
 + (UIView *)viewForData:(NSDictionary *)data
               reuseView:(__unused UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error {
     return (UIView *)data[@"view"];
 }
 

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseMultipleDataOverlapTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseMultipleDataOverlapTests.m
@@ -41,9 +41,9 @@
 
 + (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     return @{
-             @"view": [UnitTestViews viewWithLongStringOverlappingLabel],
-             @"text": [[LYTStringValues alloc] initWithValues:@[@"X", @"A long string that will cause overlap"]]
-             };
+        @"view": [UnitTestViews viewWithLongStringOverlappingLabel],
+        @"text": [[LYTStringValues alloc] initWithValues:@[@"X", @"A long string that will cause overlap"]]
+    };
 }
 
 + (UIView *)viewForData:(NSDictionary *)data

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseMultipleDataOverlapTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseMultipleDataOverlapTests.m
@@ -39,7 +39,7 @@
 
 #pragma mark - LYTViewProvider
 
-+ (NSDictionary *)dataSpecForTest {
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     return @{
              @"view": [UnitTestViews viewWithLongStringOverlappingLabel],
              @"text": [[LYTStringValues alloc] initWithValues:@[@"X", @"A long string that will cause overlap"]]
@@ -49,7 +49,8 @@
 + (UIView *)viewForData:(NSDictionary *)data
               reuseView:(UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error {
     UIViewWithLabel *reuseView = (UIViewWithLabel *)(view ? view : data[@"view"]);
     reuseView.label.text = data[@"text"];
     return reuseView;

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseNestedAccessibilityTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseNestedAccessibilityTests.m
@@ -69,11 +69,11 @@
 + (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 3 views to test. One correct view, on view with overlapping subviews and one view with a switch subview.
     return @{
-             @"view": [[LYTDataValues alloc] initWithValues:@[
-                                                                  [UnitTestViews viewWithNoProblems],
-                                                                  [UnitTestViews viewWithNestedAccessibility]
-                                                                  ]]
-             };
+        @"view": [[LYTDataValues alloc] initWithValues:@[
+            [UnitTestViews viewWithNoProblems],
+            [UnitTestViews viewWithNestedAccessibility]
+        ]]
+    };
 }
 
 + (UIView *)viewForData:(NSDictionary *)data

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseNestedAccessibilityTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseNestedAccessibilityTests.m
@@ -66,7 +66,7 @@
 
 #pragma mark - LYTViewProvider
 
-+ (NSDictionary *)dataSpecForTest {
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 3 views to test. One correct view, on view with overlapping subviews and one view with a switch subview.
     return @{
              @"view": [[LYTDataValues alloc] initWithValues:@[
@@ -79,7 +79,8 @@
 + (UIView *)viewForData:(NSDictionary *)data
               reuseView:(__unused UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing *)error {
     return (UIView *)data[@"view"];
 }
 

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseOverlapTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseOverlapTests.m
@@ -92,13 +92,13 @@
     // - One view with a switch subview.
     // - One view with a button with overlapping subviews
     return @{
-             @"view": [[LYTDataValues alloc] initWithValues:@[
-                                                                   [UnitTestViews viewWithNoProblems],
-                                                                   [UnitTestViews viewWithOverlappingViews],
-                                                                   [UnitTestViews viewWithUISwitchSubview],
-                                                                   [UnitTestViews buttonWithBackgroundImage]
-                                                                   ]]
-             };
+        @"view": [[LYTDataValues alloc] initWithValues:@[
+            [UnitTestViews viewWithNoProblems],
+            [UnitTestViews viewWithOverlappingViews],
+            [UnitTestViews viewWithUISwitchSubview],
+            [UnitTestViews buttonWithBackgroundImage]
+        ]]
+    };
 }
 
 + (UIView *)viewForData:(NSDictionary *)data

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseOverlapTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseOverlapTests.m
@@ -85,7 +85,7 @@
 
 #pragma mark - LYTViewProvider
 
-+ (NSDictionary *)dataSpecForTest {
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 4 views to test.
     // - One correct view
     // - One view with overlapping subviews
@@ -104,7 +104,8 @@
 + (UIView *)viewForData:(NSDictionary *)data
               reuseView:(__unused UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error {
     return (UIView *)data[@"view"];
 }
 

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m
@@ -120,7 +120,7 @@
 
 #pragma mark - LYTViewProvider
 
-+ (NSDictionary *)dataSpecForTest {
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     return @{
              @"someValues": [[LYTDataValues alloc] initWithValues:@[@(1), @(2), @(3)]]
              };
@@ -129,7 +129,8 @@
 + (UIView *)viewForData:(__unused NSDictionary *)data
               reuseView:(UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error {
     return view ?: [UnitTestViews viewWithNoProblems];
 }
 

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewMaxNumberOfCombinationsConfigTests.m
@@ -122,8 +122,8 @@
 
 + (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     return @{
-             @"someValues": [[LYTDataValues alloc] initWithValues:@[@(1), @(2), @(3)]]
-             };
+        @"someValues": [[LYTDataValues alloc] initWithValues:@[@(1), @(2), @(3)]]
+    };
 }
 
 + (UIView *)viewForData:(__unused NSDictionary *)data

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewSizesConfigTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewSizesConfigTests.m
@@ -74,7 +74,7 @@
 
 #pragma mark - LYTViewProvider
 
-+ (NSDictionary *)dataSpecForTest {
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     return @{
              // Empty data
              };
@@ -83,11 +83,16 @@
 + (UIView *)viewForData:(__unused NSDictionary *)data
               reuseView:(UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error {
     return view ?: [UnitTestViews viewWithNoProblems];
 }
 
-+ (void)adjustViewSize:(UIView *)view data:(__unused NSDictionary *)data size:(LYTViewSize *)size context:(__unused id)context {
++ (void)adjustViewSize:(UIView *)view 
+                  data:(__unused NSDictionary *)data
+                  size:(LYTViewSize *)size
+               context:(__unused id)context
+                 error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error {
     if (!size.width) {
         view.lyt_width = 300;
     }

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewSizesConfigTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewSizesConfigTests.m
@@ -76,8 +76,8 @@
 
 + (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     return @{
-             // Empty data
-             };
+        // Empty data
+    };
 }
 
 + (UIView *)viewForData:(__unused NSDictionary *)data

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewSizesTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewSizesTests.m
@@ -63,7 +63,7 @@
 
 #pragma mark - LYTViewProvider
 
-+ (NSDictionary *)dataSpecForTest {
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     return @{
              // Empty data
              };
@@ -72,7 +72,8 @@
 + (UIView *)viewForData:(__unused NSDictionary *)data
               reuseView:(UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error {
     return view ?: [UnitTestViews viewWithNoProblems];
 }
 
@@ -83,7 +84,11 @@
              [[LYTViewSize alloc] initWithWidth:@(200)] ];
 }
 
-+ (void)adjustViewSize:(UIView *)view data:(__unused NSDictionary *)data size:(LYTViewSize *)size context:(__unused id)context {
++ (void)adjustViewSize:(UIView *)view 
+                  data:(__unused NSDictionary *)data
+                  size:(LYTViewSize *)size
+               context:(__unused id)context
+                 error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error {
     if (!size.width) {
         view.lyt_width = 300;
     }

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewSizesTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseViewSizesTests.m
@@ -65,8 +65,8 @@
 
 + (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     return @{
-             // Empty data
-             };
+        // Empty data
+    };
 }
 
 + (UIView *)viewForData:(__unused NSDictionary *)data

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseWithinSuperviewTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseWithinSuperviewTests.m
@@ -63,7 +63,7 @@
 
 #pragma mark - LYTViewProvider
 
-+ (NSDictionary *)dataSpecForTest {
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 3 views to test. One correct view, on view with overlapping subviews and one view with a switch subview.
     return @{
              @"view": [[LYTDataValues alloc] initWithValues:@[
@@ -76,7 +76,8 @@
 + (UIView *)viewForData:(NSDictionary *)data
               reuseView:(__unused UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing *)error {
     return (UIView *)data[@"view"];
 }
 

--- a/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseWithinSuperviewTests.m
+++ b/LayoutTestTests/LayoutTestCaseTests/LayoutTestCaseWithinSuperviewTests.m
@@ -66,11 +66,11 @@
 + (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     // Return 3 views to test. One correct view, on view with overlapping subviews and one view with a switch subview.
     return @{
-             @"view": [[LYTDataValues alloc] initWithValues:@[
-                                                                  [UnitTestViews viewWithNoProblems],
-                                                                  [UnitTestViews viewWithSubviewOutOfSuperview]
-                                                                  ]]
-             };
+        @"view": [[LYTDataValues alloc] initWithValues:@[
+            [UnitTestViews viewWithNoProblems],
+            [UnitTestViews viewWithSubviewOutOfSuperview]
+        ]]
+    };
 }
 
 + (UIView *)viewForData:(NSDictionary *)data

--- a/LayoutTestTests/NullIteratorTests.m
+++ b/LayoutTestTests/NullIteratorTests.m
@@ -40,8 +40,8 @@ static NSDictionary *testData = nil;
 - (void)testNullInDictionary
 {
     testData = @{
-                 @"null": [[NullDataValues alloc] init]
-                 };
+        @"null": [[NullDataValues alloc] init]
+    };
     __block NSUInteger numberTimesCalled = 0;
     [LYTLayoutPropertyTester runPropertyTestsWithViewProvider:[self class]
                                                        validation:^(__unused UIView *view, NSDictionary *data, __unused id context) {
@@ -59,8 +59,8 @@ static NSDictionary *testData = nil;
 - (void)testNullInArray
 {
     testData = @{
-                 @"array": @[@"0", [[NullDataValues alloc] init], @(2)]
-                 };
+        @"array": @[@"0", [[NullDataValues alloc] init], @(2)]
+    };
     __block NSUInteger numberTimesCalled = 0;
     [LYTLayoutPropertyTester runPropertyTestsWithViewProvider:[self class]
                                                        validation:^(__unused UIView *view, NSDictionary *data, __unused id context) {

--- a/LayoutTestTests/NullIteratorTests.m
+++ b/LayoutTestTests/NullIteratorTests.m
@@ -87,14 +87,15 @@ static NSDictionary *testData = nil;
 
 // View Provider Protocol
 
-+ (NSDictionary *)dataSpecForTest {
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
     return testData;
 }
 
 + (UIView *)viewForData:(__unused NSDictionary *)data
               reuseView:(__unused UIView *)view
                    size:(__unused LYTViewSize *)size
-                context:(__unused id __autoreleasing *)context {
+                context:(__unused id __autoreleasing *)context
+                  error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error {
     return nil;
 }
 

--- a/LayoutTestTests/SwiftLayoutTestCaseTests.swift
+++ b/LayoutTestTests/SwiftLayoutTestCaseTests.swift
@@ -91,14 +91,14 @@ class SwiftTest: LayoutTestCase {
     }
 
     class TestView: UIView, ViewProvider {
-        @objc static func dataSpecForTest() -> [AnyHashable: Any] {
+        @objc static func dataSpecForTest() throws -> [AnyHashable: Any] {
             return [
                 "context": IntegerValues(),
                 "otherVariable": IntegerValues()
             ]
         }
 
-        static func view(forData data: [AnyHashable: Any], reuse reuseView: UIView?, size: ViewSize?, context: AutoreleasingUnsafeMutablePointer<AnyObject?>?) -> UIView {
+        static func view(forData data: [AnyHashable: Any], reuse reuseView: UIView?, size: ViewSize?, context: AutoreleasingUnsafeMutablePointer<AnyObject?>?) throws -> UIView {
             // Let's verify that this context works correctly
             context?.pointee = data["context"] as AnyObject?
             return TestView()
@@ -116,14 +116,14 @@ class SwiftTest: LayoutTestCase {
     This is identical to TestView, but it doesn't implement the view creation protocol.
     */
     class NonViewCreationProtocol: NSObject, ViewProvider {
-        @objc static func dataSpecForTest() -> [AnyHashable: Any] {
+        @objc static func dataSpecForTest() throws -> [AnyHashable: Any] {
             return [
                 "context": IntegerValues(),
                 "otherVariable": IntegerValues()
             ]
         }
 
-        @objc static func view(forData data: [AnyHashable: Any], reuse reuseView: UIView?, size: ViewSize?, context: AutoreleasingUnsafeMutablePointer<AnyObject?>?) -> UIView {
+        @objc static func view(forData data: [AnyHashable: Any], reuse reuseView: UIView?, size: ViewSize?, context: AutoreleasingUnsafeMutablePointer<AnyObject?>?) throws -> UIView {
             // Let's verify that this context works correctly
             context?.pointee = data["context"] as AnyObject?
             return TestView()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,16 +37,17 @@ The syntax is also light allowing you to add these tests easily. This test autom
   @end
 
   @implementation SampleTableViewCell (LayoutTesting)
-    + (NSDictionary *)dataSpecForTest {
+    + (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error {
       return @{
         @"text": [[LYTStringValues alloc] init],
         @"showButton": [[LYTBoolValues alloc] init]
       }
     }
-    + (UIView *)viewForData:(NSDictionary *)data
+    + (nullable UIView *)viewForData:(NSDictionary *)data
                   reuseView:(nullable UIView *)reuseView
                        size:(nullable LYTViewSize *)size
-                    context:(id _Nullable * _Nullable)context {
+                    context:(id _Nullable * _Nullable)context
+                    error:(__unused NSError * _Nullable __autoreleasing *)error {
       SampleTableViewCell *view = (SampleTableViewCell *)reuseView ?: [SampleTableViewCell viewFromNib];
       [view setupWithJSON:data];
       return view;

--- a/docs/pages/020_writingTest.rst
+++ b/docs/pages/020_writingTest.rst
@@ -15,7 +15,7 @@ LYTViewProvider
 This protocol dictates how the view is created and inflated with data. There are two methods that are required to implement. One easy way to implement it is to add an extension to the view your are trying to test.
 
 ----------------------------------
-+ (NSDictionary *)dataSpecForTest;
++ (nullable NSDictionary *)dataSpecForTestWithError:(__unused NSError * _Nullable __autoreleasing *)error;
 ----------------------------------
 
 This method defines the mock data we will use for the test. It should return an NSDictionary of any format (usually JSON), but can also include LYTDataValues subclasses. These data values are the key to writing property tests and allow the library to create many combinations of this data to inflate your view with. For instance, you can return the dictionary:
@@ -46,7 +46,7 @@ There are actually more strings and ints in the default data values and this cod
 This API makes it easy for you to write tests which will be ran on many different inputs. It's also easy for you to make your own LYTDataValues subclasses (see the LYTDataValues class for more info).
 
 --------------------------------------------------------------------------------------------------------------------------
-+ (UIView *)viewForData:(NSDictionary *)data reuseView:(UIView *)reuseView size:(LYTViewSize *)size context:(id *)context;
++ (nullable UIView *)viewForData:(NSDictionary *)data reuseView:(UIView *)reuseView size:(LYTViewSize *)size context:(id *)context error:(NSError **)error;
 --------------------------------------------------------------------------------------------------------------------------
 
 This method should inflate your view with data for the test. This data will NOT contain LYTDataValues subclasses, but instead be the output of the LYTDataValues code. A reuse view is provided if you want to reuse views for the test (recommended if you are testing cells). Size and context are additional helpers (see :doc:`030_viewSizes` and :doc:`090_testingOtherObjects`). This method should be simple to implement and look something like this:
@@ -56,10 +56,11 @@ This method should inflate your view with data for the test. This data will NOT 
   // Objective-C
   #import "LayoutTestBase.h"
 
-  + (UIView *)viewForData:(NSDictionary *)data
+  + (nullable UIView *)viewForData:(NSDictionary *)data
                 reuseView:(nullable UIView *)reuseView
                      size:(nullable LYTViewSize *)size
-                  context:(id _Nullable * _Nullable)context {
+                  context:(id _Nullable * _Nullable)context
+                  error:(__unused NSError * _Nullable __autoreleasing *)error {
     SimpleTableViewCell *cell = (SimpleTableViewCell *)reuseView ?: [SimpleTableViewCell loadFromNib];
     [cell prepareForReuse];
     [cell setupWithDictionary:data];
@@ -74,7 +75,7 @@ This method should inflate your view with data for the test. This data will NOT 
   class func viewForData(data: [NSObject: AnyObject],
                     reuseView: UIView?,
                          size: LYTViewSize?,
-                      context: AutoreleasingUnsafeMutablePointer<AnyObject?>) -> UIView {
+                      context: AutoreleasingUnsafeMutablePointer<AnyObject?>) throws -> UIView {
     let cell = reuseView as? SampleTableViewCell ?? SampleTableViewCell.loadFromNib()
     cell.prepareForReuse()
     cell.setupWithDictionary(data)

--- a/docs/pages/090_testingOtherObjects.rst
+++ b/docs/pages/090_testingOtherObjects.rst
@@ -10,10 +10,11 @@ Sample Code
 
   // Objective-C
   // LYTViewProvider
-  + (UIView *)viewForData:(NSDictionary *)data
+  + (nullable UIView *)viewForData:(NSDictionary *)data
                 reuseView:(nullable UIView *)reuseView
                      size:(nullable LYTViewSize *)size
-                  context:(id _Nullable * _Nullable)context {
+                  context:(id _Nullable * _Nullable)context
+                  error:(__unused NSError * _Nullable __autoreleasing *)error {
     // Ignoring reuse because it doesn't make sense for testing UIViewController subclasses
     SampleViewController *controller = [[SampleViewController alloc] init];
     [controller setupWithDictionary:data];
@@ -37,7 +38,7 @@ Sample Code
   class func viewForData(data: [NSObject: AnyObject],
                     reuseView: UIView?,
                          size: LYTViewSize?,
-                      context: AutoreleasingUnsafeMutablePointer<AnyObject?>) -> UIView {
+                      context: AutoreleasingUnsafeMutablePointer<AnyObject?>) throws -> UIView {
     // Ignoring reuse because it doesn't make sense for testing UIViewController subclasses
     let controller = SampleViewController()
     controller.setupWithData(data)


### PR DESCRIPTION
⚠️ The changes in this PR are breaking changes and require minor updates to the clients using the updated methods

This PR includes following changes:

- Refactor methods for `LYTViewProvider` so they are marked as throwable in Swift
- Some indent fixes
- Refactor deprecated methods from `XCTest` to use `XCTIssue` methods for reporting issues
- Bump the minor version: `6.0.4` to `6.1.0`
  - Bump the iOS minimum version to v12 which is the minimum supported version by Xcode
- Update to Xcode 15.0 suggestions and fix any warnings

I recommend reviewing this PR by commits as each commit groups related changes together